### PR TITLE
Anchor the version of nerfacc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lightning==2.0.0
 omegaconf==2.3.0
 jaxtyping
 typeguard
-git+https://github.com/KAIR-BAIR/nerfacc.git
+git+https://github.com/KAIR-BAIR/nerfacc.git@v0.5.2
 git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
 diffusers
 transformers


### PR DESCRIPTION
NerfAcc is currently being actively developed so there might be changes of API in the future. Anchor the version of it would be nice.

A side suggestion is maybe also add this for other dependences?