### PR TITLE
Initialize implicit-sdf without optimization

### DIFF
--- a/threestudio/models/geometry/implicit_sdf.py
+++ b/threestudio/models/geometry/implicit_sdf.py
@@ -73,58 +73,36 @@ class ImplicitSDF(BaseImplicitGeometry):
             )
 
     def initialize_shape(self) -> None:
-        if self.cfg.shape_init is None and not self.cfg.force_shape_init:
-            return
+        print("deprecated")
 
-        # do not initialize shape if weights are provided
-        if self.cfg.weights is not None and not self.cfg.force_shape_init:
-            return
-
-        # Initialize SDF to a given shape when no weights are provided or force_shape_init is True
-        optim = torch.optim.Adam(self.parameters(), lr=1e-3)
-        from tqdm import tqdm
-
-        for _ in tqdm(
-            range(1000), desc=f"Initializing SDF to a(n) {self.cfg.shape_init}:"
-        ):
-            points_rand = (
-                torch.rand((10000, 3), dtype=torch.float32).to(self.device) * 2.0 - 1.0
+    def get_init_sdf(self, points):
+        # blob sdf, similar to the blob density in dreamfusion
+        if self.cfg.shape_init == "ellipsoid":
+            assert (
+                isinstance(self.cfg.shape_init_params, Sized)
+                and len(self.cfg.shape_init_params) == 3
             )
-            if self.cfg.shape_init == "ellipsoid":
-                assert (
-                    isinstance(self.cfg.shape_init_params, Sized)
-                    and len(self.cfg.shape_init_params) == 3
-                )
-                size = torch.as_tensor(self.cfg.shape_init_params).to(points_rand)
-                sdf_gt = ((points_rand / size) ** 2).sum(
-                    dim=-1, keepdim=True
-                ).sqrt() - 1.0  # pseudo signed distance of an ellipsoid
-            elif self.cfg.shape_init == "sphere":
-                assert isinstance(self.cfg.shape_init_params, float)
-                radius = self.cfg.shape_init_params
-                sdf_gt = (points_rand**2).sum(dim=-1, keepdim=True).sqrt() - radius
-            elif self.cfg.shape_init == "mesh":
-                raise NotImplementedError
-            else:
-                raise ValueError(
-                    f"Unknown shape initialization type: {self.cfg.shape_init}"
-                )
-            sdf_pred = self.forward_sdf(points_rand)
-            loss = F.mse_loss(sdf_pred, sdf_gt)
-            optim.zero_grad()
-            loss.backward()
-            optim.step()
+            size = torch.as_tensor(self.cfg.shape_init_params).to(points)
+            sdf_gt = ((points / size) ** 2).sum(
+                dim=-1, keepdim=True
+            ).sqrt() - 1.0  # pseudo signed distance of an ellipsoid
+        elif self.cfg.shape_init == "sphere":
+            assert isinstance(self.cfg.shape_init_params, float)
+            radius = self.cfg.shape_init_params
+            sdf_gt = (points**2).sum(dim=-1, keepdim=True).sqrt() - radius
+        elif self.cfg.shape_init == "mesh":
+            raise NotImplementedError
+        else:
+            raise ValueError(
+                f"Unknown shape initialization type: {self.cfg.shape_init}"
+            )
+        return sdf_gt
 
     def forward(
         self, points: Float[Tensor, "*N Di"], output_normal: bool = False
     ) -> Dict[str, Float[Tensor, "..."]]:
-        points_unscaled = points  # points in the original scale
-        points = contract_to_unisphere(
-            points, self.bbox, self.unbounded
-        )  # points normalized to (0, 1)
-
-        enc = self.encoding(points.view(-1, self.cfg.n_input_dims))
-        sdf = self.sdf_network(enc).view(*points.shape[:-1], 1)
+        
+        sdf, enc = self.forward_sdf(points, return_extra=True)
         features = self.feature_network(enc).view(
             *points.shape[:-1], self.cfg.n_feature_dims
         )
@@ -146,9 +124,9 @@ class ImplicitSDF(BaseImplicitGeometry):
                         [0.0, 0.0, eps],
                         [0.0, 0.0, -eps],
                     ]
-                ).to(points_unscaled)
+                ).to(points)
                 points_offset: Float[Tensor, "... 6 3"] = (
-                    points_unscaled[..., None, :] + offsets
+                    points[..., None, :] + offsets
                 ).clamp(-self.cfg.radius, self.cfg.radius)
                 sdf_offset: Float[Tensor, "... 6 1"] = self.forward_sdf(points_offset)
                 normal = (
@@ -163,23 +141,21 @@ class ImplicitSDF(BaseImplicitGeometry):
             output.update({"normal": normal, "shading_normal": normal})
         return output
 
-    def forward_sdf(self, points: Float[Tensor, "*N Di"]) -> Float[Tensor, "*N 1"]:
+    def forward_sdf(self, points: Float[Tensor, "*N Di"], 
+            return_extra: Optional[bool]=False
+    )-> Float[Tensor, "*N 1"]:
         points_unscaled = points
         points = contract_to_unisphere(points_unscaled, self.bbox, self.unbounded)
-
-        sdf = self.sdf_network(
-            self.encoding(points.reshape(-1, self.cfg.n_input_dims))
-        ).reshape(*points.shape[:-1], 1)
-
+        enc = self.encoding(points.view(-1, self.cfg.n_input_dims))
+        sdf = self.sdf_network(enc).view(*points.shape[:-1], 1) + self.get_init_sdf(points_unscaled)
+        if return_extra:
+            return sdf, enc
         return sdf
 
     def forward_level(
         self, points: Float[Tensor, "*N Di"], threshold: Union[float, Callable]
     ) -> Tuple[Float[Tensor, "*N 1"], Optional[Float[Tensor, "*N 3"]]]:
-        points_unscaled = points
-        points = contract_to_unisphere(points_unscaled, self.bbox, self.unbounded)
-        enc = self.encoding(points.reshape(-1, self.cfg.n_input_dims))
-        sdf = self.sdf_network(enc).reshape(*points.shape[:-1], 1)
+        sdf, enc = self.forward_sdf(points, return_extra=True)
         deformation: Optional[Float[Tensor, "*N 3"]] = None
         if self.cfg.isosurface_deformable_grid:
             deformation = self.deformation_network(enc).reshape(*points.shape[:-1], 3)

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -187,7 +187,10 @@ class DeepFloydGuidance(BaseObject):
             grad = grad.clamp(-self.grad_clip_val, self.grad_clip_val)
 
         # since we omitted an item in grad, we need to use the custom function to specify the gradient
-        loss = SpecifyGradient.apply(latents, grad)
+        # loss = SpecifyGradient.apply(latents, grad)
+        # not straghtforward, use a reparameterization trick instead 
+        target = (latents-grad).detach() # the target is the denoised latents
+        loss = 0.5 * F.mse_loss(latents, target, reduction='sum')  / batch_size
         # latents.backward(grad, retain_graph=True)
 
         return {

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -287,7 +287,10 @@ class StableDiffusionGuidance(BaseObject):
             grad = grad.clamp(-self.grad_clip_val, self.grad_clip_val)
 
         # since we omitted an item in grad, we need to use the custom function to specify the gradient
-        loss = SpecifyGradient.apply(latents, grad)
+        # loss = SpecifyGradient.apply(latents, grad)
+        # not straghtforward, use a reparameterization trick instead 
+        target = (latents-grad).detach() # the target is the denoised latents
+        loss = 0.5 * F.mse_loss(latents, target, reduction='sum')  / batch_size
         # latents.backward(grad, retain_graph=True)
 
         return {


### PR DESCRIPTION
Hi, Thank you for the amazing repo!  I would like to improve the repo. 
1. SDF-based representation requires an initial shape. It is implemented by doing a few optimization steps now. 
Here I present an alternative implementation, which gives smooth initialization and  produces  comparable results. 

<img width="703" alt="image" src="https://github.com/threestudio-project/threestudio/assets/57170935/3525dbe9-29ba-45fb-95b9-6ce9a44cfa9a">

2. The customized operator `SpecifyGradient` in the SDS loss appears hack.  This reparameterization gives the equivalent gradient, and allows visualizing the loss scale during training. 
```python
# loss = SpecifyGradient.apply(latents, grad)
# not straghtforward, use a reparameterization trick instead 
target = (latents-grad).detach() # the target is the denoised latents
loss = 0.5 * F.mse_loss(latents, target, reduction='sum')  / batch_size
```
the gradient of the `latent` is `0.5*2(latents - (latents-grad)) = grad`