### PR TITLE
Refactor prompt processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A simple jupyter notebook (#55).
 - `sdf_bias` as an alternative way for SDF initialization in `implicit-volume` (#57).
-- Automatically remove outliers with a small number of faces when extracting surfaces.
+- Automatically remove outliers with a small number of faces when extracting surfaces (#61).
+- An experimental implementation of ProlificDreamer (#74).
 
 ### Changed
 
 - Remove `trainer` from the constructor arguments of prompt processors (#56).
 - Use a reparametrization trick for the SDS loss (#57).
 - Make Magic3D coarse stage use analytic normal and orientation loss.
+- Move the logic of getting text embeddings according to camera settings from prompt processors to guidance (#77).
 
 ## [v0.1.0]
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -121,6 +121,17 @@ This system has all the common configurations, along with the following unique c
 | ------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | latent_steps | int  | Number of steps for geometry optimization in latent space. In the first `latent_steps` steps, low resolution normal and mask are concatenated and fed to the latent diffusion model. After this high resolution normal is used to perform RGB space optimziation. Details are described in the Fantasia3D paper. Default: 2500 |
 
+### prolificdreamer-system
+
+This system has all the common configurations, along with the following unique configurations:
+
+| name                     | type          | description                                                                                                                                                          |
+| ------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| refinement               | bool          | Whether to perform refinement (third stage in the ProlificDreamer paper). Default: False                                                                             |
+| from_coarse              | Optional[str] | The path to the coarse stage model checkpoint. If not None and `refinement=True`, initialize the model for refinement from the specified coarse model. Default: None |
+| coarse_geometry_override | dict          | Configurations to override when initializing from coarse geometry. A typical use case is to specify an isosurface threshold value. Default: {}                       |
+| inherit_coarse_texture   | bool          | Whether to load the encoding and feature network from the coarse stage for refinement, used when `from_coarse=True`. Default: True                                   |
+
 ## Geometry
 
 Geometry models properties for locations in space, including density, SDF, feature and normal.
@@ -318,19 +329,20 @@ Given an image or its latent input, the guide should provide its gradient condit
 
 **Common configurations for guidance**
 
-| name                              | type          | description                                                                                                                                                                                           |
-| --------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enable_memory_efficient_attention | bool          | Whether to enable memory efficient attention in xformers. This will lead to lower GPU memory usage and a potential speed up at inference. Speed up at training time is not guaranteed. Default: false |
-| enable_sequential_cpu_offload     | bool          | Whether to offload all models to CPU. This will use `accelerate`, significantly reducing memory usage but slower. Default: False                                                                      |
-| enable_attention_slicing          | bool          | Whether to use sliced attention computation. This will save some memory in exchange for a small speed decrease. Default: False                                                                        |
-| enable_channels_last_format       | bool          | Whether to use Channels Last format for the unet. Default: False (Stable Diffusion) / True (DeepFloyd)                                                                                                |
-| pretrained_model_name_or_path     | str           | The pretrained model path in huggingface. Default: "runwayml/stable-diffusion-v1-5" (for `stable-diffusion-guidance`) / "DeepFloyd/IF-I-XL-v1.0" (for `deep-floyd-guidance`)                          |
-| guidance_scale                    | float         | The classifier free guidance scale. Default: 100.0 (for `stable-diffusion-guidance`) / 20.0 (for `deep-floyd-guidance`)                                                                               |
-| grad_clip                         | Optional[Any] | The gradient clip value. None or float or a list in the form of [start_step, start_value, end_value, end_step]. Default: None                                                                         |
-| half_precision_weights            | bool          | Whether to use float16 for the diffusion model. Default: True                                                                                                                                         |
-| min_step_percent                  | float         | The precent range (min value) of the random timesteps to add noise and denoise. Default: 0.02                                                                                                         |
-| max_step_percent                  | float         | The precent range (max value) of the random timesteps to add noise and denoise. Default: 0.98                                                                                                         |
-| weighting_strategy                | str           | The choice of w(t) of the sds loss, in ["sds", "uniform", "fantasia3d"]. Default: "sds"                                                                                                               |
+| name                              | type          | description                                                                                                                                                                                                                                                  |
+| --------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enable_memory_efficient_attention | bool          | Whether to enable memory efficient attention in xformers. This will lead to lower GPU memory usage and a potential speed up at inference. Speed up at training time is not guaranteed. Default: false                                                        |
+| enable_sequential_cpu_offload     | bool          | Whether to offload all models to CPU. This will use `accelerate`, significantly reducing memory usage but slower. Default: False                                                                                                                             |
+| enable_attention_slicing          | bool          | Whether to use sliced attention computation. This will save some memory in exchange for a small speed decrease. Default: False                                                                                                                               |
+| enable_channels_last_format       | bool          | Whether to use Channels Last format for the unet. Default: False (Stable Diffusion) / True (DeepFloyd)                                                                                                                                                       |
+| pretrained_model_name_or_path     | str           | The pretrained model path in huggingface. Default: "runwayml/stable-diffusion-v1-5" (for `stable-diffusion-guidance`) / "DeepFloyd/IF-I-XL-v1.0" (for `deep-floyd-guidance`) / "stabilityai/stable-diffusion-2-1-base" (for `stable-diffusion-vsd-guidance`) |
+| guidance_scale                    | float         | The classifier free guidance scale. Default: 100.0 (for `stable-diffusion-guidance`) / 20.0 (for `deep-floyd-guidance`)                                                                                                                                      |
+| grad_clip                         | Optional[Any] | The gradient clip value. None or float or a list in the form of [start_step, start_value, end_value, end_step]. Default: None                                                                                                                                |
+| half_precision_weights            | bool          | Whether to use float16 for the diffusion model. Default: True                                                                                                                                                                                                |
+| min_step_percent                  | float         | The precent range (min value) of the random timesteps to add noise and denoise. Default: 0.02                                                                                                                                                                |
+| max_step_percent                  | float         | The precent range (max value) of the random timesteps to add noise and denoise. Default: 0.98                                                                                                                                                                |
+| weighting_strategy                | str           | The choice of w(t) of the sds loss, in ["sds", "uniform", "fantasia3d"]. Default: "sds"                                                                                                                                                                      |
+| view_dependent_prompting          | bool          | Whether to use view dependent prompt, i.e. add front/side/back/overhead view to the original prompt. Default: True                                                                                                                                           |
 
 For the first three options, you can check more details in [pipe_stable_diffusion.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py) and [pipeline_if.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/deepfloyd_if/pipeline_if.py) in diffusers.
 
@@ -347,6 +359,17 @@ For the first three options, you can check more details in [pipe_stable_diffusio
 
 No specific configuration.
 
+## stable-diffusion-vsd-guidance
+
+| name                               | type  | description                                                                                                                                                     |
+| ---------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| pretrained_model_name_or_path_lora | str   | The pretrained base model path for the LoRA model. Default: "stabilityai/stable-diffusion-2-1"                                                                  |
+| guidance_scale_lora                | float | The classifier free guidance scale for the LoRA model. Default: 1.                                                                                              |
+| lora_cfg_training                  | bool  | Whether to adopt classifier free guidance training strategy in LoRA training. If True, will zero out the camera condition with a probability 0.1. Default: True |
+| max_step_percent_annealed          | float | The precent range (max value) of the random timesteps to add noise and denoise after t annealing. Default: 0.5                                                  |
+| anneal_start_step                  | int   | At which step to perform t annealing. Default: 5000                                                                                                             |
+| camera_condition_type              | str   | Which to use as the camera condition for the LoRA model, in ["extrinsics", "mvp"]. Default: "extrinsics"                                                        |
+
 ## Prompt Processors
 
 Prompt processors take a user prompt and compute text embeddings for training. The type of the prompt processor should match that of the guidance.
@@ -358,7 +381,6 @@ Prompt processors take a user prompt and compute text embeddings for training. T
 | prompt                        | str   | The text prompt. Default: "a hamburger"                                                                                                                                                                                                          |
 | negative_prompt               | str   | The uncondition text input in Classifier Free Guidance. Default: ""                                                                                                                                                                              |
 | pretrained_model_name_or_path | str   | The pretrained model path in huggingface. Default: "runwayml/stable-diffusion-v1-5" (for `stable-diffusion-prompt-processor`) / "DeepFloyd/IF-I-XL-v1.0" (fpr `deep-floyd-prompt-processor`)                                                     |
-| view_dependent_prompting      | bool  | Whether to use view dependent prompt, i.e. add front/side/back/overhead view to the original prompt. Default: True                                                                                                                               |
 | overhead_threshold            | float | Consider the view as overhead when the elevation degree > overhead_threshold. Default: 60.0                                                                                                                                                      |
 | front_threshold               | float | Consider the view as front when the azimuth degree in [-front_threshold, front_threshold]. Default: 45.0                                                                                                                                         |
 | back_threshold                | float | Consider the view as back when the azimuth degree > 180 - back_threshold or < -180 + back_threshold. Default: 45.0                                                                                                                               |

--- a/configs/prolificdreamer.yaml
+++ b/configs/prolificdreamer.yaml
@@ -68,7 +68,7 @@ system:
     lambda_vsd: 1.
     lambda_lora: 1.
     lambda_orient: 0.
-    lambda_sparsity: 0.
+    lambda_sparsity: 10.
     lambda_opaque: 0.
   optimizer:
     name: AdamW

--- a/threestudio/data/uncond.py
+++ b/threestudio/data/uncond.py
@@ -224,7 +224,7 @@ class RandomCameraIterableDataset(IterableDataset):
         c2w: Float[Tensor, "B 4 4"] = torch.cat(
             [c2w3x4, torch.zeros_like(c2w3x4[:, :1])], dim=1
         )
-        c2w[:, 3, 3] = 0.0
+        c2w[:, 3, 3] = 1.0
 
         # get directions by dividing directions_unit_focal by focal length
         focal_length: Float[Tensor, "B"] = 0.5 * self.cfg.height / torch.tan(0.5 * fovy)
@@ -320,8 +320,7 @@ class RandomCameraDataset(Dataset):
         c2w: Float[Tensor, "B 4 4"] = torch.cat(
             [c2w3x4, torch.zeros_like(c2w3x4[:, :1])], dim=1
         )
-        c2w[:, 3, 3] = 0.0
-        print(c2w.shape, c2w3x4.shape)
+        c2w[:, 3, 3] = 1.0
 
         # get directions by dividing directions_unit_focal by focal length
         focal_length: Float[Tensor, "B"] = (

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -200,10 +200,10 @@ class DeepFloydGuidance(BaseObject):
         # SpecifyGradient is not straghtforward, use a reparameterization trick instead
         target = (latents - grad).detach()
         # d(loss)/d(latents) = latents - target = latents - (latents - grad) = grad
-        loss = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
+        loss_sds = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
 
         return {
-            "sds": loss,
+            "loss_sds": loss_sds,
             "grad_norm": grad.norm(),
         }
 

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -7,9 +7,9 @@ from diffusers import IFPipeline
 from diffusers.utils.import_utils import is_xformers_available
 
 import threestudio
+from threestudio.models.prompt_processors.base import PromptProcessorOutput
 from threestudio.utils.base import BaseObject
 from threestudio.utils.misc import C, parse_version
-from threestudio.utils.ops import SpecifyGradient
 from threestudio.utils.typing import *
 
 
@@ -33,6 +33,8 @@ class DeepFloydGuidance(BaseObject):
         max_step_percent: float = 0.98
 
         weighting_strategy: str = "sds"
+
+        view_dependent_prompting: bool = True
 
     cfg: Config
 
@@ -115,8 +117,12 @@ class DeepFloydGuidance(BaseObject):
     def __call__(
         self,
         rgb: Float[Tensor, "B H W C"],
-        text_embeddings: Float[Tensor, "BB 77 768"],
+        prompt_utils: PromptProcessorOutput,
+        elevation: Float[Tensor, "B"],
+        azimuth: Float[Tensor, "B"],
+        camera_distances: Float[Tensor, "B"],
         rgb_as_latents=False,
+        **kwargs,
     ):
         batch_size = rgb.shape[0]
 
@@ -126,6 +132,10 @@ class DeepFloydGuidance(BaseObject):
         rgb_BCHW = rgb_BCHW * 2.0 - 1.0  # scale to [-1, 1] to match the diffusion range
         latents = F.interpolate(
             rgb_BCHW, (64, 64), mode="bilinear", align_corners=False
+        )
+
+        text_embeddings = prompt_utils.get_text_embeddings(
+            elevation, azimuth, camera_distances, self.cfg.view_dependent_prompting
         )
 
         # timestep ~ U(0.02, 0.98) to avoid very high/low noise level

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -300,10 +300,10 @@ class StableDiffusionGuidance(BaseObject):
         # SpecifyGradient is not straghtforward, use a reparameterization trick instead
         target = (latents - grad).detach()
         # d(loss)/d(latents) = latents - target = latents - (latents - grad) = grad
-        loss = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
+        loss_sds = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
 
         return {
-            "sds": loss,
+            "loss_sds": loss_sds,
             "grad_norm": grad.norm(),
         }
 

--- a/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
@@ -458,15 +458,15 @@ class StableDiffusionVSDGuidance(BaseModule):
         # reparameterization trick
         # d(loss)/d(latents) = latents - target = latents - (latents - grad) = grad
         target = (latents - grad).detach()
-        vsd_loss = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
+        loss_vsd = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
 
-        lora_loss = self.train_lora(
+        loss_lora = self.train_lora(
             latents, text_embeddings, text_embeddings_inp, camera_condition
         )
 
         return {
-            "vsd": vsd_loss,
-            "lora": lora_loss,
+            "loss_vsd": loss_vsd,
+            "loss_lora": loss_lora,
             "grad_norm": grad.norm(),
         }
 

--- a/threestudio/systems/dreamfusion.py
+++ b/threestudio/systems/dreamfusion.py
@@ -43,7 +43,10 @@ class DreamFusion(BaseLift3DSystem):
 
         loss = 0.0
 
-        loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         if self.C(self.cfg.loss.lambda_orient) > 0:
             if "normal" not in out:

--- a/threestudio/systems/dreamfusion.py
+++ b/threestudio/systems/dreamfusion.py
@@ -36,9 +36,9 @@ class DreamFusion(BaseLift3DSystem):
 
     def training_step(self, batch, batch_idx):
         out = self(batch)
-        text_embeddings = self.prompt_processor(**batch)
+        prompt_utils = self.prompt_processor()
         guidance_out = self.guidance(
-            out["comp_rgb"], text_embeddings, rgb_as_latents=False
+            out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
         )
 
         loss = 0.0

--- a/threestudio/systems/fantasia3d.py
+++ b/threestudio/systems/fantasia3d.py
@@ -67,7 +67,10 @@ class Fantasia3D(BaseLift3DSystem):
                 guidance_inp, prompt_utils, **batch, rgb_as_latents=False
             )
 
-        loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         for name, value in self.cfg.loss.items():
             self.log(f"train_params/{name}", self.C(value))

--- a/threestudio/systems/fantasia3d.py
+++ b/threestudio/systems/fantasia3d.py
@@ -52,19 +52,19 @@ class Fantasia3D(BaseLift3DSystem):
         loss = 0.0
 
         out = self(batch)
-        text_embeddings = self.prompt_processor(**batch)
+        prompt_utils = self.prompt_processor()
 
         if self.true_global_step < self.cfg.latent_steps:
             guidance_inp = torch.cat(
                 [out["comp_normal"] * 2.0 - 1.0, out["opacity"]], dim=-1
             )
             guidance_out = self.guidance(
-                guidance_inp, text_embeddings, rgb_as_latents=True
+                guidance_inp, prompt_utils, **batch, rgb_as_latents=True
             )
         else:
             guidance_inp = out["comp_normal"] * 2.0 - 1.0
             guidance_out = self.guidance(
-                guidance_inp, text_embeddings, rgb_as_latents=False
+                guidance_inp, prompt_utils, **batch, rgb_as_latents=False
             )
 
         loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)

--- a/threestudio/systems/imagedreamfusion.py
+++ b/threestudio/systems/imagedreamfusion.py
@@ -111,9 +111,9 @@ class ImageConditionDreamFusion(BaseLift3DSystem):
                     valid_gt_depth, valid_pred_depth
                 )
         else:
-            text_embeddings = self.prompt_processor(**batch)
+            prompt_utils = self.prompt_processor()
             guidance_out = self.guidance(
-                out["comp_rgb"], text_embeddings, rgb_as_latents=False
+                out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
             )
 
             loss += guidance_out["sds"]

--- a/threestudio/systems/latentnerf.py
+++ b/threestudio/systems/latentnerf.py
@@ -60,7 +60,10 @@ class LatentNeRF(BaseLift3DSystem):
 
         loss = 0.0
 
-        loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         if self.C(self.cfg.loss.lambda_orient) > 0:
             if "normal" not in out:

--- a/threestudio/systems/latentnerf.py
+++ b/threestudio/systems/latentnerf.py
@@ -50,9 +50,12 @@ class LatentNeRF(BaseLift3DSystem):
 
     def training_step(self, batch, batch_idx):
         out = self(batch)
-        text_embeddings = self.prompt_processor(**batch)
+        prompt_utils = self.prompt_processor()
         guidance_out = self.guidance(
-            out["comp_rgb"], text_embeddings, rgb_as_latents=not self.cfg.refinement
+            out["comp_rgb"],
+            prompt_utils,
+            **batch,
+            rgb_as_latents=not self.cfg.refinement,
         )
 
         loss = 0.0

--- a/threestudio/systems/magic3d.py
+++ b/threestudio/systems/magic3d.py
@@ -100,9 +100,9 @@ class Magic3D(BaseLift3DSystem):
 
     def training_step(self, batch, batch_idx):
         out = self(batch)
-        text_embeddings = self.prompt_processor(**batch)
+        prompt_utils = self.prompt_processor()
         guidance_out = self.guidance(
-            out["comp_rgb"], text_embeddings, rgb_as_latents=False
+            out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
         )
 
         loss = 0.0

--- a/threestudio/systems/magic3d.py
+++ b/threestudio/systems/magic3d.py
@@ -107,7 +107,10 @@ class Magic3D(BaseLift3DSystem):
 
         loss = 0.0
 
-        loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         if not self.cfg.refinement:
             if self.C(self.cfg.loss.lambda_orient) > 0:

--- a/threestudio/systems/prolificdreamer.py
+++ b/threestudio/systems/prolificdreamer.py
@@ -109,13 +109,10 @@ class ProlificDreamer(BaseLift3DSystem):
 
         loss = 0.0
 
-        loss_vsd = guidance_out["vsd"]
-        self.log("train/loss_vsd", loss_vsd)
-        loss += loss_vsd * self.C(self.cfg.loss.lambda_vsd)
-
-        loss_lora = guidance_out["lora"]
-        self.log("train/loss_lora", loss_lora)
-        loss += loss_lora * self.C(self.cfg.loss.lambda_lora)
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         if not self.cfg.refinement:
             if self.C(self.cfg.loss.lambda_orient) > 0:

--- a/threestudio/systems/sjc.py
+++ b/threestudio/systems/sjc.py
@@ -58,7 +58,11 @@ class ScoreJacobianChaining(BaseLift3DSystem):
         )
 
         loss = 0.0
-        loss += guidance_out["sds"] * self.C(self.cfg.loss.lambda_sds)
+
+        for name, value in guidance_out.items():
+            self.log(f"train/{name}", value)
+            if name.startswith("loss_"):
+                loss += value * self.C(self.cfg.loss[name.replace("loss_", "lambda_")])
 
         loss_emptiness = (
             self.C(self.cfg.loss.lambda_emptiness)

--- a/threestudio/systems/sjc.py
+++ b/threestudio/systems/sjc.py
@@ -52,9 +52,9 @@ class ScoreJacobianChaining(BaseLift3DSystem):
 
     def training_step(self, batch, batch_idx):
         out = self(batch)
-        text_embeddings = self.prompt_processor(**batch)
+        prompt_utils = self.prompt_processor()
         guidance_out = self.guidance(
-            out["comp_rgb"], text_embeddings, rgb_as_latents=True
+            out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=True
         )
 
         loss = 0.0

--- a/threestudio/utils/ops.py
+++ b/threestudio/utils/ops.py
@@ -216,7 +216,7 @@ def get_ray_directions(
 
 def get_rays(
     directions: Float[Tensor, "... 3"],
-    c2w: Float[Tensor, "... 3 4"],
+    c2w: Float[Tensor, "... 4 4"],
     keepdim=False,
     noise_scale=0.0,
 ) -> Tuple[Float[Tensor, "... 3"], Float[Tensor, "... 3"]]:
@@ -228,25 +228,25 @@ def get_rays(
             c2w = c2w[None, :, :]
         assert c2w.ndim == 3  # (N_rays, 4, 4) or (1, 4, 4)
         rays_d = (directions[:, None, :] * c2w[:, :3, :3]).sum(-1)  # (N_rays, 3)
-        rays_o = c2w[:, :, 3].expand(rays_d.shape)
+        rays_o = c2w[:, :3, 3].expand(rays_d.shape)
     elif directions.ndim == 3:  # (H, W, 3)
         assert c2w.ndim in [2, 3]
         if c2w.ndim == 2:  # (4, 4)
             rays_d = (directions[:, :, None, :] * c2w[None, None, :3, :3]).sum(
                 -1
             )  # (H, W, 3)
-            rays_o = c2w[None, None, :, 3].expand(rays_d.shape)
+            rays_o = c2w[None, None, :3, 3].expand(rays_d.shape)
         elif c2w.ndim == 3:  # (B, 4, 4)
             rays_d = (directions[None, :, :, None, :] * c2w[:, None, None, :3, :3]).sum(
                 -1
             )  # (B, H, W, 3)
-            rays_o = c2w[:, None, None, :, 3].expand(rays_d.shape)
+            rays_o = c2w[:, None, None, :3, 3].expand(rays_d.shape)
     elif directions.ndim == 4:  # (B, H, W, 3)
         assert c2w.ndim == 3  # (B, 4, 4)
         rays_d = (directions[:, :, :, None, :] * c2w[:, None, None, :3, :3]).sum(
             -1
         )  # (B, H, W, 3)
-        rays_o = c2w[:, None, None, :, 3].expand(rays_d.shape)
+        rays_o = c2w[:, None, None, :3, 3].expand(rays_d.shape)
 
     # add camera noise to avoid grid-like artifect
     # https://github.com/ashawkey/stable-dreamfusion/blob/49c3d4fa01d68a4f027755acf94e1ff6020458cc/nerf/utils.py#L373
@@ -277,7 +277,7 @@ def get_projection_matrix(
 
 
 def get_mvp_matrix(
-    c2w: Float[Tensor, "B 3 4"], proj_mtx: Float[Tensor, "B 4 4"]
+    c2w: Float[Tensor, "B 4 4"], proj_mtx: Float[Tensor, "B 4 4"]
 ) -> Float[Tensor, "B 4 4"]:
     # calculate w2c from c2w: R' = Rt, t' = -Rt * t
     # mathematically equivalent to (c2w)^-1


### PR DESCRIPTION
Changes:

- Prompt processors now return an instance of `PromptProcessorOutput`, which contains text embeddings, view-dependent text embeddings, direction configs, and a function to get text embeddings from camera settings. With this change, we can more easily implement VSD and Perp-Neg.
- `view_dependent_prompting` is now an option for guidance, not prompt processors.
- The returned dict of guidance now contains several items with keys starting with `loss_`. These items will be treated as loss terms, multiplied with the corresponding `lambda_`, and added to the final loss. With this change, we can easily adapt VSD to other systems, simply changing the guidance and loss lambdas in the configuration file.
- The LoRA of ProlificDreamer takes view-independent text embeddings instead of view-dependent ones.