### PR TITLE
refactor zero123

### DIFF
--- a/configs/zero123.yaml
+++ b/configs/zero123.yaml
@@ -12,7 +12,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
   default_azimuth_deg: 0.0
   default_camera_distance: 3.2
   default_fovy_deg: 20.0
-  random_camera:  # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
+  random_camera: # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
     height: 64
     width: 64
     eval_height: 256
@@ -22,7 +22,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
     elevation_range: [-10, 60]
     azimuth_range: [-180, 180]
     camera_distance_range: [3.0, 3.5]
-    fovy_range: [20.0, 20.0]  # Zero123 has fixed fovy
+    fovy_range: [20.0, 20.0] # Zero123 has fixed fovy
     camera_perturb: 0.0
     center_perturb: 0.0
     up_perturb: 0.0
@@ -83,8 +83,8 @@ system:
   renderer:
     radius: ${system.geometry.radius}
     num_samples_per_ray: 512
-    lambda_normal_smooth: ${system.loss.lambda_normal_smooth}
-    lambda_3d_normal_smooth: ${system.loss.lambda_3d_normal_smooth}
+    return_comp_normal: ${gt0:${system.loss.lambda_normal_smooth}}
+    return_normal_perturb: ${gt0:${system.loss.lambda_3d_normal_smooth}}
 
   prompt_processor_type: "zero123-prompt-processor"
   prompt_processor:

--- a/configs/zero123_claforte.yaml
+++ b/configs/zero123_claforte.yaml
@@ -12,7 +12,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
   default_azimuth_deg: 0.0
   default_camera_distance: 3.2
   default_fovy_deg: 20.0
-  random_camera:  # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
+  random_camera: # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
     height: 64
     width: 64
     eval_height: 256
@@ -22,7 +22,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
     elevation_range: [-10, 60]
     azimuth_range: [-180, 180]
     camera_distance_range: [3.2, 3.3]
-    fovy_range: [20.0, 20.0]  # Zero123 has fixed fovy
+    fovy_range: [20.0, 20.0] # Zero123 has fixed fovy
     camera_perturb: 0.0
     center_perturb: 0.0
     up_perturb: 0.0
@@ -83,8 +83,8 @@ system:
   renderer:
     radius: ${system.geometry.radius}
     num_samples_per_ray: 512
-    lambda_normal_smooth: ${system.loss.lambda_normal_smooth}
-    lambda_3d_normal_smooth: ${system.loss.lambda_3d_normal_smooth}
+    return_comp_normal: ${gt0:${system.loss.lambda_normal_smooth}}
+    return_normal_perturb: ${gt0:${system.loss.lambda_3d_normal_smooth}}
 
   prompt_processor_type: "zero123-prompt-processor"
   prompt_processor:

--- a/configs/zero123_finitediff.yaml
+++ b/configs/zero123_finitediff.yaml
@@ -12,7 +12,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
   default_azimuth_deg: 0.0
   default_camera_distance: 3.2
   default_fovy_deg: 20.0
-  random_camera:  # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
+  random_camera: # threestudio/data/uncond.py -> RandomCameraDataModuleConfig
     height: 64
     width: 64
     eval_height: 256
@@ -22,7 +22,7 @@ data: # threestudio/data/image.py -> SingleImageDataModuleConfig
     elevation_range: [-10, 90]
     azimuth_range: [-180, 180]
     camera_distance_range: [3.0, 3.5]
-    fovy_range: [20., 20.]  # Zero123 has fixed fovy
+    fovy_range: [20., 20.] # Zero123 has fixed fovy
     camera_perturb: 0.0
     center_perturb: 0.0
     up_perturb: 0.0
@@ -74,8 +74,8 @@ system:
   renderer_type: "nerf-volume-renderer"
   renderer:
     num_samples_per_ray: 512
-    lambda_normal_smooth: ${system.loss.lambda_normal_smooth}
-    lambda_3d_normal_smooth: ${system.loss.lambda_3d_normal_smooth}
+    return_comp_normal: ${gt0:${system.loss.lambda_normal_smooth}}
+    return_normal_perturb: ${gt0:${system.loss.lambda_3d_normal_smooth}}
 
   prompt_processor_type: "zero123-prompt-processor"
   prompt_processor:

--- a/launch.py
+++ b/launch.py
@@ -146,12 +146,7 @@ def main() -> None:
         rank_zero_only(
             lambda: write_to_text(
                 os.path.join(cfg.trial_dir, "log.txt"),
-                ["python " + " ".join(sys.argv), str(args), str(cfg)],
-            )
-        )()
-        rank_zero_only(
-            lambda: shutil.copyfile(
-                args.config, os.path.join(cfg.trial_dir, os.path.basename(args.config))
+                ["python " + " ".join(sys.argv), str(args)],
             )
         )()
 

--- a/threestudio/models/renderers/nerf_volume_renderer.py
+++ b/threestudio/models/renderers/nerf_volume_renderer.py
@@ -24,8 +24,8 @@ class NeRFVolumeRenderer(VolumeRenderer):
         randomized: bool = True
         eval_chunk_size: int = 160000
         grid_prune: bool = True
-        lambda_normal_smooth: float = 0
-        lambda_3d_normal_smooth: float = 0
+        return_comp_normal: bool = False
+        return_normal_perturb: bool = False
 
     cfg: Config
 
@@ -179,7 +179,7 @@ class NeRFVolumeRenderer(VolumeRenderer):
                 }
             )
             if "normal" in geo_out:
-                if self.cfg.lambda_normal_smooth > 0:  # TODO
+                if self.cfg.return_comp_normal:
                     comp_normal: Float[Tensor, "Nr 3"] = nerfacc.accumulate_along_rays(
                         weights[..., 0],
                         values=geo_out["normal"],
@@ -197,7 +197,7 @@ class NeRFVolumeRenderer(VolumeRenderer):
                             ),
                         }
                     )
-                if self.cfg.lambda_3d_normal_smooth > 0:  # TODO
+                if self.cfg.return_normal_perturb:
                     normal_perturb = self.geometry(
                         positions + torch.randn_like(positions) * 1e-2,
                         output_normal=self.material.requires_normal,
@@ -205,7 +205,7 @@ class NeRFVolumeRenderer(VolumeRenderer):
                     out.update({"normal_perturb": normal_perturb})
         else:
             if "normal" in geo_out:
-                comp_normal: Float[Tensor, "Nr 3"] = nerfacc.accumulate_along_rays(
+                comp_normal = nerfacc.accumulate_along_rays(
                     weights[..., 0],
                     values=geo_out["normal"],
                     ray_indices=ray_indices,

--- a/threestudio/utils/config.py
+++ b/threestudio/utils/config.py
@@ -19,6 +19,7 @@ OmegaConf.register_new_resolver("idiv", lambda a, b: a // b)
 OmegaConf.register_new_resolver("basename", lambda p: os.path.basename(p))
 OmegaConf.register_new_resolver("rmspace", lambda s, sub: s.replace(" ", sub))
 OmegaConf.register_new_resolver("tuple2", lambda s: [float(s), float(s)])
+OmegaConf.register_new_resolver("gt0", lambda s: s > 0)
 # ======================================================= #
 
 


### PR DESCRIPTION
- remove redundant config saving in `launch.py`
- change `lambda_normal_smooth` and `lambda_3d_normal_smooth` to `return_comp_normal` and `return_normal_perturb` in `nerf-volume-renderer`