### PR TITLE
widen black formatter (88 -> 100 chars)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100


### PR DESCRIPTION
@bennyguo this is a very simple way to enforce a non-default max width. I ran some quick tests with a relatively large font in vscode, 2 files side-by-side plus the bar on the left, and I recommend a value between 100 and 110.

The moment we merge this however, we might want to do a project-wide reformatting of the python files. If we don't, when someone pushes a commit, their actual change will be burried in tons of unrelated formatting changes. sigh. I volunteer to figure this out and do this right after the PR is merged, if you agree with this plan.

@thuliu-yt16 @voletiv FYI. If you have large outstanding changes, I recommend you merge them before we do this.