### PR TITLE
Set diffusion model to evaluation mode

### DIFF
--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -81,7 +81,7 @@ class DeepFloydGuidance(BaseObject):
         if self.cfg.enable_channels_last_format:
             self.pipe.unet.to(memory_format=torch.channels_last)
 
-        self.unet = self.pipe.unet
+        self.unet = self.pipe.unet.eval()
 
         for p in self.unet.parameters():
             p.requires_grad_(False)

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -83,8 +83,8 @@ class StableDiffusionGuidance(BaseObject):
             self.pipe.unet.to(memory_format=torch.channels_last)
 
         # Create model
-        self.vae = self.pipe.vae
-        self.unet = self.pipe.unet
+        self.vae = self.pipe.vae.eval()
+        self.unet = self.pipe.unet.eval()
 
         for p in self.vae.parameters():
             p.requires_grad_(False)


### PR DESCRIPTION
Set the diffusion model to evaluation mode as a precaution. Currently, The training mode and evaluation mode will not affect the model's performance since stable diffusion utilizes GroupNorm in U-Net and LayerNorm in CLIP.