### PR TITLE
Validate empty rays

### DIFF
--- a/threestudio/models/renderers/nerf_volume_renderer.py
+++ b/threestudio/models/renderers/nerf_volume_renderer.py
@@ -9,7 +9,7 @@ from threestudio.models.background.base import BaseBackground
 from threestudio.models.geometry.base import BaseImplicitGeometry
 from threestudio.models.materials.base import BaseMaterial
 from threestudio.models.renderers.base import VolumeRenderer
-from threestudio.utils.ops import chunk_batch, check_empty_rays
+from threestudio.utils.ops import chunk_batch, validate_empty_rays
 from threestudio.utils.typing import *
 
 
@@ -64,7 +64,7 @@ class NeRFVolumeRenderer(VolumeRenderer):
         n_rays = rays_o_flatten.shape[0]
 
         def sigma_fn(t_starts, t_ends, ray_indices):
-            ray_indices, t_starts, t_ends = check_empty_rays(ray_indices, t_starts, t_ends, rays_o.device)
+            ray_indices, t_starts, t_ends = validate_empty_rays(ray_indices, t_starts, t_ends)
             t_starts, t_ends = t_starts[..., None], t_ends[..., None]
             t_origins = rays_o_flatten[ray_indices]
             t_positions = (t_starts + t_ends) / 2.0
@@ -104,7 +104,7 @@ class NeRFVolumeRenderer(VolumeRenderer):
                     cone_angle=0.0,
                 )
 
-        ray_indices, t_starts_, t_ends_ = check_empty_rays(ray_indices, t_starts_, t_ends_, rays_o.device)
+        ray_indices, t_starts_, t_ends_ = validate_empty_rays(ray_indices, t_starts_, t_ends_)
         ray_indices = ray_indices.long()
         t_starts, t_ends = t_starts_[..., None], t_ends_[..., None]
         t_origins = rays_o_flatten[ray_indices]

--- a/threestudio/models/renderers/neus_volume_renderer.py
+++ b/threestudio/models/renderers/neus_volume_renderer.py
@@ -10,7 +10,7 @@ from threestudio.models.background.base import BaseBackground
 from threestudio.models.geometry.base import BaseImplicitGeometry
 from threestudio.models.materials.base import BaseMaterial
 from threestudio.models.renderers.base import VolumeRenderer
-from threestudio.utils.ops import chunk_batch
+from threestudio.utils.ops import chunk_batch, check_empty_rays
 from threestudio.utils.typing import *
 
 
@@ -104,6 +104,7 @@ class NeuSVolumeRenderer(VolumeRenderer):
         n_rays = rays_o_flatten.shape[0]
 
         def alpha_fn(t_starts, t_ends, ray_indices):
+            ray_indices, t_starts, t_ends = check_empty_rays(ray_indices, t_starts, t_ends, rays_o.device)
             t_starts, t_ends = t_starts[..., None], t_ends[..., None]
             t_origins = rays_o_flatten[ray_indices]
             t_positions = (t_starts + t_ends) / 2.0
@@ -152,6 +153,7 @@ class NeuSVolumeRenderer(VolumeRenderer):
                     cone_angle=0.0,
                 )
 
+        ray_indices, t_starts_, t_ends_ = check_empty_rays(ray_indices, t_starts_, t_ends_, rays_o.device)
         ray_indices = ray_indices.long()
         t_starts, t_ends = t_starts_[..., None], t_ends_[..., None]
         t_origins = rays_o_flatten[ray_indices]
@@ -161,7 +163,6 @@ class NeuSVolumeRenderer(VolumeRenderer):
         positions = t_origins + t_dirs * t_positions
         t_intervals = t_ends - t_starts
 
-        # TODO: still proceed if the scene is empty
 
         if self.training:
             geo_out = self.geometry(positions, output_normal=True)

--- a/threestudio/models/renderers/neus_volume_renderer.py
+++ b/threestudio/models/renderers/neus_volume_renderer.py
@@ -10,7 +10,7 @@ from threestudio.models.background.base import BaseBackground
 from threestudio.models.geometry.base import BaseImplicitGeometry
 from threestudio.models.materials.base import BaseMaterial
 from threestudio.models.renderers.base import VolumeRenderer
-from threestudio.utils.ops import chunk_batch, check_empty_rays
+from threestudio.utils.ops import chunk_batch, validate_empty_rays
 from threestudio.utils.typing import *
 
 
@@ -104,7 +104,7 @@ class NeuSVolumeRenderer(VolumeRenderer):
         n_rays = rays_o_flatten.shape[0]
 
         def alpha_fn(t_starts, t_ends, ray_indices):
-            ray_indices, t_starts, t_ends = check_empty_rays(ray_indices, t_starts, t_ends, rays_o.device)
+            ray_indices, t_starts, t_ends = validate_empty_rays(ray_indices, t_starts, t_ends)
             t_starts, t_ends = t_starts[..., None], t_ends[..., None]
             t_origins = rays_o_flatten[ray_indices]
             t_positions = (t_starts + t_ends) / 2.0
@@ -153,7 +153,7 @@ class NeuSVolumeRenderer(VolumeRenderer):
                     cone_angle=0.0,
                 )
 
-        ray_indices, t_starts_, t_ends_ = check_empty_rays(ray_indices, t_starts_, t_ends_, rays_o.device)
+        ray_indices, t_starts_, t_ends_ = validate_empty_rays(ray_indices, t_starts_, t_ends_)
         ray_indices = ray_indices.long()
         t_starts, t_ends = t_starts_[..., None], t_ends_[..., None]
         t_origins = rays_o_flatten[ray_indices]

--- a/threestudio/utils/ops.py
+++ b/threestudio/utils/ops.py
@@ -437,3 +437,12 @@ def perpendicular_component(x: Float[Tensor, "B C H W"], y: Float[Tensor, "B C H
         ).view(-1, 1, 1, 1)
         * y
     )
+
+
+def check_empty_rays(ray_indices, t_start, t_end, device):
+    if ray_indices.nelement() == 0:
+        print("Empty rays_indices!")
+        ray_indices = torch.LongTensor([0]).to(device)
+        t_start = torch.Tensor([0]).to(device)
+        t_end = torch.Tensor([0]).to(device)
+    return ray_indices, t_start, t_end

--- a/threestudio/utils/ops.py
+++ b/threestudio/utils/ops.py
@@ -8,6 +8,7 @@ from igl import fast_winding_number_for_meshes, point_mesh_squared_distance, rea
 from torch.autograd import Function
 from torch.cuda.amp import custom_bwd, custom_fwd
 
+import threestudio
 from threestudio.utils.typing import *
 
 
@@ -439,10 +440,10 @@ def perpendicular_component(x: Float[Tensor, "B C H W"], y: Float[Tensor, "B C H
     )
 
 
-def check_empty_rays(ray_indices, t_start, t_end, device):
+def validate_empty_rays(ray_indices, t_start, t_end):
     if ray_indices.nelement() == 0:
-        print("Empty rays_indices!")
-        ray_indices = torch.LongTensor([0]).to(device)
-        t_start = torch.Tensor([0]).to(device)
-        t_end = torch.Tensor([0]).to(device)
+        threestudio.warn("Empty rays_indices!")
+        ray_indices = torch.LongTensor([0]).to(ray_indices)
+        t_start = torch.Tensor([0]).to(ray_indices)
+        t_end = torch.Tensor([0]).to(ray_indices)
     return ray_indices, t_start, t_end


### PR DESCRIPTION
Validate empty rays based on the number of elements. If `ray_indices` is empty, use the first ray and set its start and end to zero. This validation avoids errors and will not influence the training process when rays are empty.

Before:
![error](https://github.com/threestudio-project/threestudio/assets/24589363/554d32ea-1fe6-44fe-86d2-c7806d769115)

After:
![warning](https://github.com/threestudio-project/threestudio/assets/24589363/afe01a54-0438-49bd-90cf-31eba2fe0c17)
