### PR TITLE
Patch-based renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Easy-to-use geometry conversion by `system.geometry_convert_from`. This is used in the Magic3D and ProlificDreamer system and may inspire applications connecting multiple systems/algorithms (#105).
 - Support prompt debiasing and manually assignment of view-dependent prompts (#98).
 - The implementation of Perp-Neg (#98).
+- Support patch-based renderer (#154).
 
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -328,6 +328,15 @@ Renderers takes geometry, material, and background to produce images given camer
 | ------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | context_type | str  | Rasterization context type used by nvdiffrast, in ["gl", "cuda"]. See the [nvdiffrast documentation](https://nvlabs.github.io/nvdiffrast/#rasterizing-with-cuda-vs-opengl-new) for more details. |
 
+### patch-renderer
+| name                  | type  | description                                                                                               |
+| --------------------- | ----- | --------------------------------------------------------------------------------------------------------- |
+| patch_size            | int   | The size of the local patch. Default: 128                                                                 |
+| global_downsample     | int   | Downsample scale of the original rendering size. Default: 4                                               |
+| global_detach         | bool  | Whether to detach the gradient of the downsampled image. Default: False                                   |
+| base_renderer_type    | str   | The type of base renderer.                                                                                |
+| base_renderer         | VolumeRenderer.Config  | The configuration of the base renderer.                                                  |
+
 ## Guidance
 
 Given an image or its latent input, the guide should provide its gradient conditioned on a text input so that the image can be optimized with gradient descent to better match the text.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -329,6 +329,7 @@ Renderers takes geometry, material, and background to produce images given camer
 | context_type | str  | Rasterization context type used by nvdiffrast, in ["gl", "cuda"]. See the [nvdiffrast documentation](https://nvlabs.github.io/nvdiffrast/#rasterizing-with-cuda-vs-opengl-new) for more details. |
 
 ### patch-renderer
+The patch-renderer first renders a full low-resolution downsampled image and then randomly renders a local patch at the original resolution level, which can significantly reduce memory usage during high-resolution training. 
 | name                  | type  | description                                                                                               |
 | --------------------- | ----- | --------------------------------------------------------------------------------------------------------- |
 | patch_size            | int   | The size of the local patch. Default: 128                                                                 |

--- a/threestudio/models/renderers/__init__.py
+++ b/threestudio/models/renderers/__init__.py
@@ -4,4 +4,5 @@ from . import (
     nerf_volume_renderer,
     neus_volume_renderer,
     nvdiff_rasterizer,
+    patch_renderer
 )

--- a/threestudio/models/renderers/patch_renderer.py
+++ b/threestudio/models/renderers/patch_renderer.py
@@ -28,10 +28,7 @@ class PatchRenderer(VolumeRenderer):
         material: BaseMaterial,
         background: BaseBackground,
     ) -> None:
-        cfg_copy = self.cfg.copy()
-        del cfg_copy.patch_size
-        del cfg_copy.base_renderer_type
-        self.base_renderer = threestudio.find(self.cfg.base_renderer_type)(cfg_copy.base_renderer, 
+        self.base_renderer = threestudio.find(self.cfg.base_renderer_type)(self.cfg.base_renderer, 
             geometry=geometry,
             material=material,
             background=background

--- a/threestudio/models/renderers/patch_renderer.py
+++ b/threestudio/models/renderers/patch_renderer.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+
+import nerfacc
+import torch
+import torch.nn.functional as F
+
+import threestudio
+from threestudio.models.background.base import BaseBackground
+from threestudio.models.geometry.base import BaseImplicitGeometry
+from threestudio.models.materials.base import BaseMaterial
+from threestudio.models.renderers.base import VolumeRenderer
+from threestudio.models.renderers.nerf_volume_renderer import NeRFVolumeRenderer
+from threestudio.utils.base import BaseModule
+from threestudio.utils.misc import get_device
+from threestudio.utils.ops import chunk_batch
+from threestudio.utils.rasterize import NVDiffRasterizerContext
+from threestudio.utils.typing import *
+
+
+@threestudio.register("patch-renderer")
+class PatchRenderer(VolumeRenderer):
+    @dataclass
+    class Config(VolumeRenderer.Config):
+        patch_size: int = 128
+        base_renderer_type: str = ""
+        base_renderer: Optional[VolumeRenderer.Config] = None
+        global_detach: bool = False
+    
+    cfg: Config
+    def configure(
+        self,
+        geometry: BaseImplicitGeometry,
+        material: BaseMaterial,
+        background: BaseBackground,
+    ) -> None:
+        cfg_copy = self.cfg.copy()
+        del cfg_copy.patch_size
+        del cfg_copy.base_renderer_type
+        self.base_renderer = threestudio.find(self.cfg.base_renderer_type)(cfg_copy.base_renderer, 
+            geometry=geometry,
+            material=material,
+            background=background
+        )
+
+    def forward(
+        self,
+        rays_o: Float[Tensor, "B H W 3"],
+        rays_d: Float[Tensor, "B H W 3"],
+        light_positions: Float[Tensor, "B 3"],
+        bg_color: Optional[Tensor] = None,
+        **kwargs
+    ) -> Dict[str, Float[Tensor, "..."]]:
+        B, H, W, _ = rays_o.shape
+        
+        if self.base_renderer.training:
+            scale_ratio = 4
+            global_rays_o = torch.nn.functional.interpolate(
+                rays_o.permute(0, 3, 1, 2), (H // scale_ratio, W // scale_ratio), mode='bilinear'
+            ).permute(0, 2, 3, 1)
+            global_rays_d = torch.nn.functional.interpolate(
+                rays_d.permute(0, 3, 1, 2), (H // scale_ratio, W // scale_ratio), mode='bilinear'
+            ).permute(0, 2, 3, 1)
+
+            out_base = self.base_renderer(global_rays_o, global_rays_d, light_positions, bg_color, **kwargs)
+            if self.cfg.global_detach:
+                comp_rgb = out_base["comp_rgb"].detach()
+            else:
+                comp_rgb = out_base["comp_rgb"]
+            comp_rgb = F.interpolate(comp_rgb.permute(0, 3, 1, 2), (H, W), mode='bilinear').permute(0, 2, 3, 1)
+
+            patch_x = torch.randint(0, W-self.cfg.patch_size, (1,)).item()
+            patch_y = torch.randint(0, H-self.cfg.patch_size, (1,)).item()
+            patch_rays_o = rays_o[:, patch_y:patch_y+self.cfg.patch_size, patch_x:patch_x+self.cfg.patch_size]
+            patch_rays_d = rays_d[:, patch_y:patch_y+self.cfg.patch_size, patch_x:patch_x+self.cfg.patch_size]
+            out = self.base_renderer(patch_rays_o, patch_rays_d, light_positions, bg_color, **kwargs)
+            patch_comp_rgb = out["comp_rgb"]
+            comp_rgb[:, patch_y:patch_y+self.cfg.patch_size, patch_x:patch_x+self.cfg.patch_size] = patch_comp_rgb
+
+            rt_out_base = torch.randint(0, 2, (1,)).item()
+            if rt_out_base:
+                out_base.update({
+                    "comp_rgb": comp_rgb
+                })
+                out = out_base
+            else:
+                out.update({
+                    "comp_rgb": comp_rgb
+                })
+        else:
+            out = self.base_renderer(rays_o, rays_d, light_positions, bg_color, **kwargs)
+
+        return out
+
+    def update_step(
+        self, epoch: int, global_step: int, on_load_weights: bool = False
+    ) -> None:
+        self.base_renderer.update_step(epoch, global_step, on_load_weights)
+
+    def train(self, mode=True):
+        return self.base_renderer.train(mode)
+
+    def eval(self):
+        return self.base_renderer.eval()


### PR DESCRIPTION
Support the general patch-based renderer. The ```patch_renderer``` can significantly reduce memory usage during high-resolution training. The ```patch_renderer```  first renders a full low-resolution downsampled image and then randomly renders a local patch at the original resolution level. The ```patch_renderer``` can be combined with any existing renderer to reduce their memory usage. Here is an explanation of its configuration:
- patch_size: the size of the local patch.
- global_downsample: downsample scale of the original rendering size.
- global_detach: option to detach or not detach the gradient of the downsampled image.
- base_renderer_type and base_renderer: configurations of any existing renderer.

Here is an example:
```
  renderer_type: "patch-renderer"
  renderer:
    base_renderer_type: "nerf-volume-renderer"
    base_renderer:
      radius: ${system.geometry.radius}
      num_samples_per_ray: 512
    patch_size: 128
    global_downsample: 4
    global_detach: false
```

Utilizing the patch-renderer for 512x512 training with VSD loss will consume ~20GB of memory.

Drawbacks:
- The training efficiency is reduced as the ```patch_renderer``` only renders a portion of the image in each iteration.
- The rendered image in training consists of low-resolution and high-resolution portions, which can potentially affect the guidance of the diffusion model, leading to a decrease in overall quality.