### PR TITLE
Fixes saving noise-levels in guidance_eval

### DIFF
--- a/threestudio/systems/zero123.py
+++ b/threestudio/systems/zero123.py
@@ -283,14 +283,8 @@ class Zero123(BaseLift3DSystem):
             ),
             name="train_step",
             step=self.true_global_step,
+            noise_levels=guidance_eval_out["noise_levels"],
         )
-
-        img = Image.open(self.get_save_path(filename))
-        draw = ImageDraw.Draw(img)
-        for i, n in enumerate(guidance_eval_out["noise_levels"]):
-            draw.text((1, (img.size[1] // B) * i + 1), f"{n:.02f}", (255, 255, 255))
-            draw.text((0, (img.size[1] // B) * i), f"{n:.02f}", (0, 0, 0))
-        img.save(self.get_save_path(filename))
 
     def validation_step(self, batch, batch_idx):
         out = self(batch)

--- a/threestudio/utils/saving.py
+++ b/threestudio/utils/saving.py
@@ -9,11 +9,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import trimesh
-import wandb
 from matplotlib import cm
 from matplotlib.colors import LinearSegmentedColormap
+from PIL import Image, ImageDraw
 from pytorch_lightning.loggers import WandbLogger
 
+import wandb
 from threestudio.models.mesh import Mesh
 from threestudio.utils.typing import *
 
@@ -280,8 +281,24 @@ class SaverMixin:
         align=DEFAULT_GRID_KWARGS["align"],
         name: Optional[str] = None,
         step: Optional[int] = None,
+        noise_levels: Optional[float] = None,
     ):
         img = self.get_image_grid_(imgs, align=align)
+
+        if noise_levels is not None:
+            img = Image.fromarray(img)
+            draw = ImageDraw.Draw(img)
+            for i, n in enumerate(noise_levels):
+                draw.text(
+                    (1, (img.size[1] // len(noise_levels)) * i + 1),
+                    f"{n:.02f}",
+                    (255, 255, 255),
+                )
+                draw.text(
+                    (0, (img.size[1] // len(noise_levels)) * i), f"{n:.02f}", (0, 0, 0)
+                )
+            img = np.asarray(img)
+
         filepath = self.get_save_path(filename)
         cv2.imwrite(filepath, img)
         if name and self._wandb_logger:

--- a/threestudio/utils/saving.py
+++ b/threestudio/utils/saving.py
@@ -281,7 +281,7 @@ class SaverMixin:
         align=DEFAULT_GRID_KWARGS["align"],
         name: Optional[str] = None,
         step: Optional[int] = None,
-        noise_levels: Optional[float] = None,
+        noise_levels: Optional[List[float]] = None,
     ):
         img = self.get_image_grid_(imgs, align=align)
 


### PR DESCRIPTION
Minor fix in saving noise_levels for wandb. Doesn't affect anything other than guidance_eval, which is only used in zero123 so far.

Fixes issue of saving noise level with guidance_eval image : earlier, the image was saved, read, noise level was printed on it, then the image was saved again. Now the noise level is first printed on image, then image is saved.