### PR TITLE
ImageDreamfusion accumulate grad, guidance_eval in sd,if

### DIFF
--- a/configs/experimental/imagecondition.yaml
+++ b/configs/experimental/imagecondition.yaml
@@ -13,6 +13,8 @@ data:
     eval_elevation_deg: 0.
     eval_camera_distance: 1.2
     eval_fovy_deg: 60.
+    n_val_views: 30
+    n_test_views: 120
 
 system_type: "image-condition-dreamfusion-system"
 system:

--- a/configs/experimental/imagecondition.yaml
+++ b/configs/experimental/imagecondition.yaml
@@ -7,6 +7,7 @@ data_type: "single-image-datamodule"
 data:
   image_path: ./load/images/hamburger_rgba.png
   random_camera:
+    batch_size: 4
     eval_height: 256
     eval_width: 256
     eval_elevation_deg: 0.
@@ -61,10 +62,23 @@ system:
   guidance:
     pretrained_model_name_or_path: "runwayml/stable-diffusion-v1-5"
     guidance_scale: 100.
+    weighting_strategy: sds # sds, uniform, fantasia3d
+
+  # prompt_processor_type: "deep-floyd-prompt-processor"
+  # prompt_processor:
+  #   pretrained_model_name_or_path: "DeepFloyd/IF-I-XL-v1.0"
+  #   prompt: "a DSLR photo of a delicious hamburger"
+
+  # guidance_type: "deep-floyd-guidance"
+  # guidance:
+  #   pretrained_model_name_or_path: "DeepFloyd/IF-I-XL-v1.0"
+  #   guidance_scale: 20.
+  #   weighting_strategy: sds # sds, uniform, fantasia3d
 
   freq:
     n_ref: 2
     ref_only_steps: 100
+    guidance_eval: 0
 
   loggers:
     wandb:
@@ -78,6 +92,7 @@ system:
     lambda_mask: 1.
     lambda_depth: [0.0, 0.0, 1.0, 10000]
     lambda_normal_smooth: 0.0
+    lambda_3d_normal_smooth: 0.0
     lambda_orient: 0.0
     lambda_sparsity: 0.0
     lambda_opaque: 0.0
@@ -103,7 +118,7 @@ trainer:
   max_steps: 10000
   log_every_n_steps: 1
   num_sanity_val_steps: 0
-  val_check_interval: 500
+  val_check_interval: 100
   limit_val_batches: 6
   enable_progress_bar: true
   precision: 16-mixed

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -261,9 +261,9 @@ class DeepFloydGuidance(BaseObject):
                 "noise_pred": torch.cat([noise_pred, predicted_variance], dim=1),
             }
             guidance_eval_out = self.guidance_eval(**guidance_eval_utils)
-            return guidance_out, guidance_eval_out
-        else:
-            return guidance_out
+            guidance_out.update({"eval": guidance_eval_out})
+
+        return guidance_out
 
     @torch.cuda.amp.autocast(enabled=False)
     @torch.no_grad()

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers import IFPipeline
 from diffusers.utils.import_utils import is_xformers_available
+from tqdm import tqdm
 
 import threestudio
 from threestudio.models.prompt_processors.base import PromptProcessorOutput
@@ -102,6 +103,11 @@ class DeepFloydGuidance(BaseObject):
         threestudio.info(f"Loaded Deep Floyd!")
 
     @torch.cuda.amp.autocast(enabled=False)
+    def set_min_max_steps(self, min_step_percent=0.02, max_step_percent=0.98):
+        self.min_step = int(self.num_train_timesteps * min_step_percent)
+        self.max_step = int(self.num_train_timesteps * max_step_percent)
+
+    @torch.cuda.amp.autocast(enabled=False)
     def forward_unet(
         self,
         latents: Float[Tensor, "..."],
@@ -123,6 +129,7 @@ class DeepFloydGuidance(BaseObject):
         azimuth: Float[Tensor, "B"],
         camera_distances: Float[Tensor, "B"],
         rgb_as_latents=False,
+        guidance_eval=False,
         **kwargs,
     ):
         batch_size = rgb.shape[0]
@@ -180,6 +187,7 @@ class DeepFloydGuidance(BaseObject):
                 e_pos + accum_grad
             )
         else:
+            neg_guidance_weights = None
             text_embeddings = prompt_utils.get_text_embeddings(
                 elevation, azimuth, camera_distances, self.cfg.view_dependent_prompting
             )
@@ -238,9 +246,149 @@ class DeepFloydGuidance(BaseObject):
         # d(loss)/d(latents) = latents - target = latents - (latents - grad) = grad
         loss_sds = 0.5 * F.mse_loss(latents, target, reduction="sum") / batch_size
 
-        return {
+        guidance_out = {
             "loss_sds": loss_sds,
             "grad_norm": grad.norm(),
+        }
+
+        if guidance_eval:
+            guidance_eval_utils = {
+                "use_perp_neg": prompt_utils.use_perp_neg,
+                "neg_guidance_weights": neg_guidance_weights,
+                "text_embeddings": text_embeddings,
+                "t_orig": t,
+                "latents_noisy": latents_noisy,
+                "noise_pred": torch.cat([noise_pred, predicted_variance], dim=1),
+            }
+            guidance_eval_out = self.guidance_eval(**guidance_eval_utils)
+            return guidance_out, guidance_eval_out
+        else:
+            return guidance_out
+
+    @torch.cuda.amp.autocast(enabled=False)
+    @torch.no_grad()
+    def get_noise_pred(
+        self,
+        latents_noisy,
+        t,
+        text_embeddings,
+        use_perp_neg=False,
+        neg_guidance_weights=None,
+    ):
+        batch_size = latents_noisy.shape[0]
+        if use_perp_neg:
+            latent_model_input = torch.cat([latents_noisy] * 4, dim=0)
+            noise_pred = self.forward_unet(
+                latent_model_input,
+                torch.cat([t.reshape(1)] * 4).to(self.device),
+                encoder_hidden_states=text_embeddings,
+            )  # (4B, 6, 64, 64)
+
+            noise_pred_text, _ = noise_pred[:batch_size].split(3, dim=1)
+            noise_pred_uncond, _ = noise_pred[batch_size : batch_size * 2].split(
+                3, dim=1
+            )
+            noise_pred_neg, _ = noise_pred[batch_size * 2 :].split(3, dim=1)
+
+            e_pos = noise_pred_text - noise_pred_uncond
+            accum_grad = 0
+            n_negative_prompts = neg_guidance_weights.shape[-1]
+            for i in range(n_negative_prompts):
+                e_i_neg = noise_pred_neg[i::n_negative_prompts] - noise_pred_uncond
+                accum_grad += neg_guidance_weights[:, i].view(
+                    -1, 1, 1, 1
+                ) * perpendicular_component(e_i_neg, e_pos)
+
+            noise_pred = noise_pred_uncond + self.cfg.guidance_scale * (
+                e_pos + accum_grad
+            )
+        else:
+            latent_model_input = torch.cat([latents_noisy] * 2, dim=0)
+            noise_pred = self.forward_unet(
+                latent_model_input,
+                torch.cat([t.reshape(1)] * 2).to(self.device),
+                encoder_hidden_states=text_embeddings,
+            )  # (2B, 6, 64, 64)
+
+            # perform guidance (high scale from paper!)
+            noise_pred_text, noise_pred_uncond = noise_pred.chunk(2)
+            noise_pred_text, predicted_variance = noise_pred_text.split(3, dim=1)
+            noise_pred_uncond, _ = noise_pred_uncond.split(3, dim=1)
+            noise_pred = noise_pred_text + self.cfg.guidance_scale * (
+                noise_pred_text - noise_pred_uncond
+            )
+
+        return torch.cat([noise_pred, predicted_variance], dim=1)
+
+    @torch.cuda.amp.autocast(enabled=False)
+    @torch.no_grad()
+    def guidance_eval(
+        self,
+        t_orig,
+        text_embeddings,
+        latents_noisy,
+        noise_pred,
+        use_perp_neg=False,
+        neg_guidance_weights=None,
+    ):
+        # use only 50 timesteps, and find nearest of those to t
+        self.scheduler.set_timesteps(50)
+        self.scheduler.timesteps_gpu = self.scheduler.timesteps.to(self.device)
+        bs = latents_noisy.shape[0]  # batch size
+        large_enough_idxs = self.scheduler.timesteps_gpu.expand(
+            [bs, -1]
+        ) > t_orig.unsqueeze(
+            -1
+        )  # sized [bs,50] > [bs,1]
+        idxs = torch.min(large_enough_idxs, dim=1)[1]
+        t = self.scheduler.timesteps_gpu[idxs]
+
+        fracs = list((t / self.scheduler.config.num_train_timesteps).cpu().numpy())
+        imgs_noisy = latents_noisy.permute(0, 2, 3, 1)
+
+        # get prev latent
+        latents_1step = []
+        pred_1orig = []
+        for b in range(len(t)):
+            step_output = self.scheduler.step(
+                noise_pred[b : b + 1], t[b], latents_noisy[b : b + 1]
+            )
+            latents_1step.append(step_output["prev_sample"])
+            pred_1orig.append(step_output["pred_original_sample"])
+        latents_1step = torch.cat(latents_1step)
+        pred_1orig = torch.cat(pred_1orig)
+        imgs_1step = latents_1step.permute(0, 2, 3, 1)
+        imgs_1orig = pred_1orig.permute(0, 2, 3, 1)
+
+        latents_final = []
+        for b, i in enumerate(idxs):
+            latents = latents_1step[b : b + 1]
+            text_emb = (
+                text_embeddings[
+                    [b, b + len(idxs), b + 2 * len(idxs), b + 3 * len(idxs)], ...
+                ]
+                if use_perp_neg
+                else text_embeddings[[b, b + len(idxs)], ...]
+            )
+            neg_guid = neg_guidance_weights[b : b + 1] if use_perp_neg else None
+            for t in tqdm(self.scheduler.timesteps[i + 1 :], leave=False):
+                # pred noise
+                noise_pred = self.get_noise_pred(
+                    latents, t, text_emb, use_perp_neg, neg_guid
+                )
+                # get prev latent
+                latents = self.scheduler.step(noise_pred, t, latents)["prev_sample"]
+            latents_final.append(latents)
+
+        latents_final = torch.cat(latents_final)
+        imgs_final = latents_final.permute(0, 2, 3, 1)
+
+        return {
+            "noise_levels": fracs,
+            "imgs_noisy": imgs_noisy,
+            "imgs_1step": imgs_1step,
+            "imgs_1orig": imgs_1orig,
+            "imgs_final": imgs_final,
         }
 
     def update_step(self, epoch: int, global_step: int, on_load_weights: bool = False):

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -431,9 +431,9 @@ class StableDiffusionGuidance(BaseObject):
 
         if guidance_eval:
             guidance_eval_out = self.guidance_eval(**guidance_eval_utils)
-            return guidance_out, guidance_eval_out
-        else:
-            return guidance_out
+            guidance_out.update({"eval": guidance_eval_out})
+
+        return guidance_out
 
     @torch.cuda.amp.autocast(enabled=False)
     @torch.no_grad()

--- a/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
@@ -212,6 +212,11 @@ class StableDiffusionVSDGuidance(BaseModule):
 
         threestudio.info(f"Loaded Stable Diffusion!")
 
+    @torch.cuda.amp.autocast(enabled=False)
+    def set_min_max_steps(self, min_step_percent=0.02, max_step_percent=0.98):
+        self.min_step = int(self.num_train_timesteps * min_step_percent)
+        self.max_step = int(self.num_train_timesteps * max_step_percent)
+
     @property
     def pipe(self):
         return self.submodules.pipe

--- a/threestudio/models/guidance/zero123_guidance.py
+++ b/threestudio/models/guidance/zero123_guidance.py
@@ -324,10 +324,16 @@ class Zero123Guidance(BaseObject):
         }
 
         if guidance_eval:
-            guidance_eval_out = self.guidance_eval(cond, t, latents_noisy, noise_pred)
-            return guidance_out, guidance_eval_out
-        else:
-            return guidance_out
+            guidance_eval_utils = {
+                "cond": cond,
+                "t_orig": t,
+                "latents_noisy": latents_noisy,
+                "noise_pred": noise_pred,
+            }
+            guidance_eval_out = self.guidance_eval(**guidance_eval_utils)
+            guidance_out.update({"eval": guidance_eval_out})
+
+        return guidance_out
 
     @torch.cuda.amp.autocast(enabled=False)
     @torch.no_grad()

--- a/threestudio/systems/imagedreamfusion.py
+++ b/threestudio/systems/imagedreamfusion.py
@@ -1,4 +1,6 @@
+import os
 import random
+import shutil
 from dataclasses import dataclass, field
 
 import torch
@@ -225,7 +227,7 @@ class ImageConditionDreamFusion(BaseLift3DSystem):
     def validation_step(self, batch, batch_idx):
         out = self(batch)
         self.save_image_grid(
-            f"it{self.true_global_step}-{batch['index'][0]}.png",
+            f"it{self.true_global_step}-val/{batch['index'][0]}.png",
             (
                 [
                     {
@@ -263,12 +265,26 @@ class ImageConditionDreamFusion(BaseLift3DSystem):
                     "kwargs": {"cmap": None, "data_range": (0, 1)},
                 },
             ],
-            name="validation_step",
+            name=f"validation_step_batchidx_{batch_idx}"
+            if batch_idx in [0, 7, 15, 23, 29]
+            else None,
             step=self.true_global_step,
         )
 
     def on_validation_epoch_end(self):
-        pass
+        filestem = f"it{self.true_global_step}-val"
+        self.save_img_sequence(
+            filestem,
+            filestem,
+            "(\d+)\.png",
+            save_format="mp4",
+            fps=30,
+            name="validation_epoch_end",
+            step=self.true_global_step,
+        )
+        shutil.rmtree(
+            os.path.join(self.get_save_dir(), f"it{self.true_global_step}-val")
+        )
 
     def test_step(self, batch, batch_idx):
         out = self(batch)

--- a/threestudio/systems/zero123.py
+++ b/threestudio/systems/zero123.py
@@ -132,8 +132,6 @@ class Zero123(BaseLift3DSystem):
                 rgb_as_latents=False,
                 guidance_eval=guidance_eval,
             )
-            if guidance_eval:
-                guidance_out, guidance_eval_out = guidance_out
             # claforte: TODO: rename the loss_terms keys
             set_loss("sds", guidance_out["loss_sds"])
 
@@ -198,7 +196,9 @@ class Zero123(BaseLift3DSystem):
         self.log(f"train/loss_{guidance}", loss)
 
         if guidance_eval:
-            self.guidance_evaluation_save(out["comp_rgb"].detach(), guidance_eval_out)
+            self.guidance_evaluation_save(
+                out["comp_rgb"].detach(), guidance_out["eval"]
+            )
 
         return {"loss": loss}
 
@@ -228,66 +228,6 @@ class Zero123(BaseLift3DSystem):
         # sch.step()
 
         return {"loss": total_loss}
-
-    def guidance_evaluation_save(self, comp_rgb, guidance_eval_out):
-        B, size = comp_rgb.shape[:2]
-        resize = lambda x: F.interpolate(
-            x.permute(0, 3, 1, 2), (size, size), mode="bilinear", align_corners=False
-        ).permute(0, 2, 3, 1)
-        filename = f"it{self.true_global_step}-train.png"
-
-        def merge12(x):
-            return x.reshape(-1, *x.shape[2:])
-
-        self.save_image_grid(
-            filename,
-            [
-                {
-                    "type": "rgb",
-                    "img": merge12(comp_rgb),
-                    "kwargs": {"data_format": "HWC"},
-                },
-            ]
-            + (
-                [
-                    {
-                        "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_noisy"])),
-                        "kwargs": {"data_format": "HWC"},
-                    }
-                ]
-            )
-            + (
-                [
-                    {
-                        "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_1step"])),
-                        "kwargs": {"data_format": "HWC"},
-                    }
-                ]
-            )
-            + (
-                [
-                    {
-                        "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_1orig"])),
-                        "kwargs": {"data_format": "HWC"},
-                    }
-                ]
-            )
-            + (
-                [
-                    {
-                        "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_final"])),
-                        "kwargs": {"data_format": "HWC"},
-                    }
-                ]
-            ),
-            name="train_step",
-            step=self.true_global_step,
-            noise_levels=guidance_eval_out["noise_levels"],
-        )
 
     def validation_step(self, batch, batch_idx):
         out = self(batch)


### PR DESCRIPTION
1. Accumulates grad in imagedreamfusion
Fixes imagedreamfusion to accumulate grads from ref and guidance

2. Adds guidance_eval to stable_diffusion, deep_floyd
Adds the ability to optionally evaluate guidance periodically, in stable_diffusion and deep_floyd (as done in zero123)

This does not affect current working of stable_diffusion, deep_floyd, it only adds the option to visualize the guidance.

## Example

I used the following command to check the results with stable diffusion guidance:
`python launch.py --config configs/experimental/imagecondition.yaml --train --gpu 0 system.freq.ref_only_steps=20 system.freq.guidance_eval=13`

To run with deep floyd guidance, I uncommented the requisite lines in `configs/experimental/imagecondition.yaml`.

First, since `ref_only_steps=20`, it should run with just rgb_loss for 20 iterations.
Then, from 21st iteration, it should also compute guidance loss.
Then, since `freq.guidance_eval=13`, at the 26th iteration, it should save the results of guidance_eval:

With stable-diffusion:
![it26-train](https://github.com/threestudio-project/threestudio/assets/22424247/703242d3-48d6-4e37-a323-b15486eaa8f4)

With deep-floyd:
![it52-train](https://github.com/threestudio-project/threestudio/assets/22424247/160e6e3e-b199-49ca-a21c-0a197e2e2a94)
