### PR TITLE
New algorithm for finite difference based on 3 points

### DIFF
--- a/threestudio/models/geometry/implicit_volume.py
+++ b/threestudio/models/geometry/implicit_volume.py
@@ -47,7 +47,7 @@ class ImplicitVolume(BaseImplicitGeometry):
         )
         normal_type: Optional[
             str
-        ] = "finite_difference"  # in ['pred', 'finite_difference']
+        ] = "finite_difference"  # in ['pred', 'finite_difference', 'finite_difference_laplacian']
         finite_difference_normal_eps: float = 0.01
 
         # automatically determine the threshold
@@ -132,30 +132,46 @@ class ImplicitVolume(BaseImplicitGeometry):
             output.update({"features": features})
 
         if output_normal:
-            if self.cfg.normal_type == "finite_difference":
+            if self.cfg.normal_type == "finite_difference" or self.cfg.normal_type == "finite_difference_laplacian":
                 # TODO: use raw density
                 eps = self.cfg.finite_difference_normal_eps
-                offsets: Float[Tensor, "6 3"] = torch.as_tensor(
-                    [
-                        [eps, 0.0, 0.0],
-                        [-eps, 0.0, 0.0],
-                        [0.0, eps, 0.0],
-                        [0.0, -eps, 0.0],
-                        [0.0, 0.0, eps],
-                        [0.0, 0.0, -eps],
-                    ]
-                ).to(points_unscaled)
-                points_offset: Float[Tensor, "... 6 3"] = (
-                    points_unscaled[..., None, :] + offsets
-                ).clamp(-self.cfg.radius, self.cfg.radius)
-                density_offset: Float[Tensor, "... 6 1"] = self.forward_density(
-                    points_offset
-                )
-                normal = (
-                    -0.5
-                    * (density_offset[..., 0::2, 0] - density_offset[..., 1::2, 0])
-                    / eps
-                )
+                if self.cfg.normal_type == "finite_difference_laplacian":
+                    offsets: Float[Tensor, "6 3"] = torch.as_tensor(
+                        [
+                            [eps, 0.0, 0.0],
+                            [-eps, 0.0, 0.0],
+                            [0.0, eps, 0.0],
+                            [0.0, -eps, 0.0],
+                            [0.0, 0.0, eps],
+                            [0.0, 0.0, -eps],
+                        ]
+                    ).to(points_unscaled)
+                    points_offset: Float[Tensor, "... 6 3"] = (
+                        points_unscaled[..., None, :] + offsets
+                    ).clamp(-self.cfg.radius, self.cfg.radius)
+                    density_offset: Float[Tensor, "... 6 1"] = self.forward_density(
+                        points_offset
+                    )
+                    normal = (
+                        -0.5
+                        * (density_offset[..., 0::2, 0] - density_offset[..., 1::2, 0])
+                        / eps
+                    )
+                else:
+                    offsets: Float[Tensor, "3 3"] = torch.as_tensor(
+                        [
+                            [eps, 0.0, 0.0],
+                            [0.0, eps, 0.0],
+                            [0.0, 0.0, eps]
+                        ]
+                    ).to(points_unscaled)
+                    points_offset: Float[Tensor, "... 3 3"] = (
+                        points_unscaled[..., None, :] + offsets
+                    ).clamp(-self.cfg.radius, self.cfg.radius)
+                    density_offset: Float[Tensor, "... 3 1"] = self.forward_density(points_offset)
+                    normal = (
+                        (density_offset[..., 0::1, 0] - density) / eps
+                    )
                 normal = F.normalize(normal, dim=-1)
             elif self.cfg.normal_type == "pred":
                 normal = self.normal_network(enc).view(*points.shape[:-1], 3)

--- a/threestudio/models/geometry/volume_grid.py
+++ b/threestudio/models/geometry/volume_grid.py
@@ -23,7 +23,7 @@ class VolumeGrid(BaseImplicitGeometry):
         density_blob_std: float = 0.5
         normal_type: Optional[
             str
-        ] = "finite_difference"  # in ['pred', 'finite_difference']
+        ] = "finite_difference"  # in ['pred', 'finite_difference', 'finite_difference_laplacian']
 
         # automatically determine the threshold
         isosurface_threshold: Union[float, str] = "auto"
@@ -98,29 +98,45 @@ class VolumeGrid(BaseImplicitGeometry):
         }
 
         if output_normal:
-            if self.cfg.normal_type == "finite_difference":
+            if self.cfg.normal_type == "finite_difference" or self.cfg.normal_type == "finite_difference_laplacian":
                 eps = 1.0e-3
-                offsets: Float[Tensor, "6 3"] = torch.as_tensor(
-                    [
-                        [eps, 0.0, 0.0],
-                        [-eps, 0.0, 0.0],
-                        [0.0, eps, 0.0],
-                        [0.0, -eps, 0.0],
-                        [0.0, 0.0, eps],
-                        [0.0, 0.0, -eps],
-                    ]
-                ).to(points_unscaled)
-                points_offset: Float[Tensor, "... 6 3"] = (
-                    points_unscaled[..., None, :] + offsets
-                ).clamp(-self.cfg.radius, self.cfg.radius)
-                density_offset: Float[Tensor, "... 6 1"] = self.forward_density(
-                    points_offset
-                )
-                normal = (
-                    -0.5
-                    * (density_offset[..., 0::2, 0] - density_offset[..., 1::2, 0])
-                    / eps
-                )
+                if self.cfg.normal_type == "finite_difference_laplacian":
+                    offsets: Float[Tensor, "6 3"] = torch.as_tensor(
+                        [
+                            [eps, 0.0, 0.0],
+                            [-eps, 0.0, 0.0],
+                            [0.0, eps, 0.0],
+                            [0.0, -eps, 0.0],
+                            [0.0, 0.0, eps],
+                            [0.0, 0.0, -eps],
+                        ]
+                    ).to(points_unscaled)
+                    points_offset: Float[Tensor, "... 6 3"] = (
+                        points_unscaled[..., None, :] + offsets
+                    ).clamp(-self.cfg.radius, self.cfg.radius)
+                    density_offset: Float[Tensor, "... 6 1"] = self.forward_density(
+                        points_offset
+                    )
+                    normal = (
+                        -0.5
+                        * (density_offset[..., 0::2, 0] - density_offset[..., 1::2, 0])
+                        / eps
+                    )
+                else:
+                    offsets: Float[Tensor, "3 3"] = torch.as_tensor(
+                        [
+                            [eps, 0.0, 0.0],
+                            [0.0, eps, 0.0],
+                            [0.0, 0.0, eps]
+                        ]
+                    ).to(points_unscaled)
+                    points_offset: Float[Tensor, "... 3 3"] = (
+                        points_unscaled[..., None, :] + offsets
+                    ).clamp(-self.cfg.radius, self.cfg.radius)
+                    density_offset: Float[Tensor, "... 3 1"] = self.forward_density(points_offset)
+                    normal = (
+                        (density_offset[..., 0::1, 0] - density) / eps
+                    )
                 normal = F.normalize(normal, dim=-1)
             elif self.cfg.normal_type == "pred":
                 normal = self.get_trilinear_feature(points, self.normal_grid)


### PR DESCRIPTION
Rename the original calculation of finite difference as ```finite_difference_laplacian```. The new algorithm for the finite difference is based on 3 points, resulting in reduced memory consumption and improved rendering speed.

In the dreamfusion experiments:
- finite_difference_laplacian, 5.0it/s, 9500MB
- finite_difference, 5.3it/s, 6800MB
- analytic, 5.3it/s, 5200MB