### PR TITLE
Fix bugs in Nerfacc caused by the validation of empty rays

### DIFF
--- a/threestudio/models/renderers/nerf_volume_renderer.py
+++ b/threestudio/models/renderers/nerf_volume_renderer.py
@@ -64,7 +64,6 @@ class NeRFVolumeRenderer(VolumeRenderer):
         n_rays = rays_o_flatten.shape[0]
 
         def sigma_fn(t_starts, t_ends, ray_indices):
-            ray_indices, t_starts, t_ends = validate_empty_rays(ray_indices, t_starts, t_ends)
             t_starts, t_ends = t_starts[..., None], t_ends[..., None]
             t_origins = rays_o_flatten[ray_indices]
             t_positions = (t_starts + t_ends) / 2.0

--- a/threestudio/models/renderers/neus_volume_renderer.py
+++ b/threestudio/models/renderers/neus_volume_renderer.py
@@ -112,7 +112,6 @@ class NeuSVolumeRenderer(VolumeRenderer):
         n_rays = rays_o_flatten.shape[0]
 
         def alpha_fn(t_starts, t_ends, ray_indices):
-            ray_indices, t_starts, t_ends = validate_empty_rays(ray_indices, t_starts, t_ends)
             t_starts, t_ends = t_starts[..., None], t_ends[..., None]
             t_origins = rays_o_flatten[ray_indices]
             t_positions = (t_starts + t_ends) / 2.0

--- a/threestudio/utils/ops.py
+++ b/threestudio/utils/ops.py
@@ -122,7 +122,8 @@ def chunk_batch(func: Callable, chunk_size: int, *args, **kwargs) -> Any:
     ), "No tensor found in args or kwargs, cannot determine batch size."
     out = defaultdict(list)
     out_type = None
-    for i in range(0, B, chunk_size):
+    # max(1, B) to support B == 0
+    for i in range(0, max(1, B), chunk_size):
         out_chunk = func(
             *[
                 arg[i : i + chunk_size] if isinstance(arg, torch.Tensor) else arg


### PR DESCRIPTION
Following the suggestion by @bennyguo,  fix bugs in Nerfacc caused by the validation of empty rays. 