### PR TITLE
Adds set_min_max_steps to all guidance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,5 +39,6 @@ kornia
 taming-transformers-rom1504
 git+https://github.com/openai/CLIP.git
 
-#controlnet
+# controlnet
 controlnet_aux
+mediapipe

--- a/threestudio/models/guidance/__init__.py
+++ b/threestudio/models/guidance/__init__.py
@@ -1,8 +1,8 @@
 from . import (
+    controlnet_guidance,
     deep_floyd_guidance,
+    instructpix2pix_guidance,
     stable_diffusion_guidance,
     stable_diffusion_vsd_guidance,
     zero123_guidance,
-    controlnet_guidance,
-    instructpix2pix_guidance
 )

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -91,8 +91,10 @@ class DeepFloydGuidance(BaseObject):
         self.scheduler = self.pipe.scheduler
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        if isinstance(self.cfg.min_step_percent, int) and isinstance(
+            self.cfg.max_step_percent, int
+        ):
+            self.set_min_max_steps(self.cfg.min_step_percent, self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device

--- a/threestudio/models/guidance/instructpix2pix_guidance.py
+++ b/threestudio/models/guidance/instructpix2pix_guidance.py
@@ -1,19 +1,18 @@
 from dataclasses import dataclass
-import torch
+
 import cv2
 import numpy as np
+import torch
 import torch.nn.functional as F
+from diffusers import DDIMScheduler, StableDiffusionInstructPix2PixPipeline
 from tqdm import tqdm
-from diffusers import (
-    DDIMScheduler,
-    StableDiffusionInstructPix2PixPipeline,
-)
 
 import threestudio
 from threestudio.models.prompt_processors.base import PromptProcessorOutput
 from threestudio.utils.base import BaseObject
 from threestudio.utils.misc import parse_version
 from threestudio.utils.typing import *
+
 
 @threestudio.register("stable-diffusion-instructpix2pix-guidance")
 class InstructPix2PixGuidance(BaseObject):
@@ -28,7 +27,7 @@ class InstructPix2PixGuidance(BaseObject):
         enable_attention_slicing: bool = False
         enable_channels_last_format: bool = False
         guidance_scale: float = 7.5
-        condition_scale: float  = 1.5
+        condition_scale: float = 1.5
         grad_clip: Optional[
             Any
         ] = None  # field(default_factory=lambda: [0, 2.0, 8.0, 1000])
@@ -40,7 +39,7 @@ class InstructPix2PixGuidance(BaseObject):
         diffusion_steps: int = 20
 
         use_sds: bool = False
-    
+
     cfg: Config
 
     def configure(self) -> None:
@@ -55,17 +54,18 @@ class InstructPix2PixGuidance(BaseObject):
             "feature_extractor": None,
             "requires_safety_checker": False,
             "torch_dtype": self.weights_dtype,
-            "cache_dir": self.cfg.cache_dir
+            "cache_dir": self.cfg.cache_dir,
         }
 
         self.pipe = StableDiffusionInstructPix2PixPipeline.from_pretrained(
-            self.cfg.ip2p_name_or_path,
-            **pipe_kwargs).to(self.device)
+            self.cfg.ip2p_name_or_path, **pipe_kwargs
+        ).to(self.device)
         self.scheduler = DDIMScheduler.from_pretrained(
-            self.cfg.ddim_scheduler_name_or_path, 
-            subfolder="scheduler", 
-            torch_dtype=self.weights_dtype, 
-            cache_dir=self.cfg.cache_dir)
+            self.cfg.ddim_scheduler_name_or_path,
+            subfolder="scheduler",
+            torch_dtype=self.weights_dtype,
+            cache_dir=self.cfg.cache_dir,
+        )
         self.scheduler.set_timesteps(self.cfg.diffusion_steps)
 
         if self.cfg.enable_memory_efficient_attention:
@@ -99,8 +99,10 @@ class InstructPix2PixGuidance(BaseObject):
             p.requires_grad_(False)
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        if isinstance(self.cfg.min_step_percent, int) and isinstance(
+            self.cfg.max_step_percent, int
+        ):
+            self.set_min_max_steps(self.cfg.min_step_percent, self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device
@@ -109,7 +111,12 @@ class InstructPix2PixGuidance(BaseObject):
         self.grad_clip_val: Optional[float] = None
 
         threestudio.info(f"Loaded InstructPix2Pix!")
-    
+
+    @torch.cuda.amp.autocast(enabled=False)
+    def set_min_max_steps(self, min_step_percent=0.02, max_step_percent=0.98):
+        self.min_step = int(self.num_train_timesteps * min_step_percent)
+        self.max_step = int(self.num_train_timesteps * max_step_percent)
+
     @torch.cuda.amp.autocast(enabled=False)
     def forward_unet(
         self,
@@ -123,7 +130,7 @@ class InstructPix2PixGuidance(BaseObject):
             t.to(self.weights_dtype),
             encoder_hidden_states=encoder_hidden_states.to(self.weights_dtype),
         ).sample.to(input_dtype)
-    
+
     @torch.cuda.amp.autocast(enabled=False)
     def encode_images(
         self, imgs: Float[Tensor, "B 3 512 512"]
@@ -133,7 +140,7 @@ class InstructPix2PixGuidance(BaseObject):
         posterior = self.vae.encode(imgs.to(self.weights_dtype)).latent_dist
         latents = posterior.sample() * self.vae.config.scaling_factor
         return latents.to(input_dtype)
-    
+
     @torch.cuda.amp.autocast(enabled=False)
     def encode_cond_images(
         self, imgs: Float[Tensor, "B 3 512 512"]
@@ -145,7 +152,7 @@ class InstructPix2PixGuidance(BaseObject):
         uncond_image_latents = torch.zeros_like(latents)
         latents = torch.cat([latents, latents, uncond_image_latents], dim=0)
         return latents.to(input_dtype)
-    
+
     @torch.cuda.amp.autocast(enabled=False)
     def decode_latents(
         self,
@@ -167,7 +174,7 @@ class InstructPix2PixGuidance(BaseObject):
         text_embeddings: Float[Tensor, "BB 77 768"],
         latents: Float[Tensor, "B 4 64 64"],
         image_cond_latents: Float[Tensor, "B 4 64 64"],
-        t: Int[Tensor, "B"]
+        t: Int[Tensor, "B"],
     ) -> Float[Tensor, "B 4 64 64"]:
         self.scheduler.config.num_train_timesteps = t.item()
         self.scheduler.set_timesteps(self.cfg.diffusion_steps)
@@ -178,17 +185,22 @@ class InstructPix2PixGuidance(BaseObject):
             threestudio.debug("Start editing...")
             # sections of code used from https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
             for i, t in enumerate(self.scheduler.timesteps):
-
                 # predict the noise residual with unet, NO grad!
                 with torch.no_grad():
                     # pred noise
                     latent_model_input = torch.cat([latents] * 3)
-                    latent_model_input = torch.cat([latent_model_input, image_cond_latents], dim=1)
+                    latent_model_input = torch.cat(
+                        [latent_model_input, image_cond_latents], dim=1
+                    )
 
-                    noise_pred = self.forward_unet(latent_model_input, t, encoder_hidden_states=text_embeddings)
+                    noise_pred = self.forward_unet(
+                        latent_model_input, t, encoder_hidden_states=text_embeddings
+                    )
 
                 # perform classifier-free guidance
-                noise_pred_text, noise_pred_image, noise_pred_uncond = noise_pred.chunk(3)
+                noise_pred_text, noise_pred_image, noise_pred_uncond = noise_pred.chunk(
+                    3
+                )
                 noise_pred = (
                     noise_pred_uncond
                     + self.cfg.guidance_scale * (noise_pred_text - noise_pred_image)
@@ -199,13 +211,13 @@ class InstructPix2PixGuidance(BaseObject):
                 latents = self.scheduler.step(noise_pred, t, latents).prev_sample
             threestudio.debug("Editing finished.")
         return latents
-    
+
     def compute_grad_sds(
         self,
         text_embeddings: Float[Tensor, "BB 77 768"],
         latents: Float[Tensor, "B 4 64 64"],
         image_cond_latents: Float[Tensor, "B 4 64 64"],
-        t: Int[Tensor, "B"]
+        t: Int[Tensor, "B"],
     ):
         with torch.no_grad():
             # add noise
@@ -213,10 +225,13 @@ class InstructPix2PixGuidance(BaseObject):
             latents_noisy = self.scheduler.add_noise(latents, noise, t)
             # pred noise
             latent_model_input = torch.cat([latents_noisy] * 3)
-            latent_model_input = torch.cat([latent_model_input, image_cond_latents], dim=1)
+            latent_model_input = torch.cat(
+                [latent_model_input, image_cond_latents], dim=1
+            )
 
-            noise_pred = self.forward_unet(latent_model_input, t, 
-                encoder_hidden_states=text_embeddings)
+            noise_pred = self.forward_unet(
+                latent_model_input, t, encoder_hidden_states=text_embeddings
+            )
 
         noise_pred_text, noise_pred_image, noise_pred_uncond = noise_pred.chunk(3)
         noise_pred = (
@@ -228,7 +243,7 @@ class InstructPix2PixGuidance(BaseObject):
         w = (1 - self.alphas[t]).view(-1, 1, 1, 1)
         grad = w * (noise_pred - noise)
         return grad
-    
+
     def __call__(
         self,
         rgb: Float[Tensor, "B H W C"],
@@ -253,10 +268,10 @@ class InstructPix2PixGuidance(BaseObject):
         cond_latents = self.encode_cond_images(cond_rgb_BCHW_512)
 
         temp = torch.zeros(1).to(rgb.device)
-        text_embeddings = prompt_utils.get_text_embeddings(
-            temp, temp, temp, False
-        )
-        text_embeddings = torch.cat([text_embeddings, text_embeddings[-1:]], dim=0) # [positive, negative, negative]
+        text_embeddings = prompt_utils.get_text_embeddings(temp, temp, temp, False)
+        text_embeddings = torch.cat(
+            [text_embeddings, text_embeddings[-1:]], dim=0
+        )  # [positive, negative, negative]
 
         # timestep ~ U(0.02, 0.98) to avoid very high/low noise level
         t = torch.randint(
@@ -266,7 +281,7 @@ class InstructPix2PixGuidance(BaseObject):
             dtype=torch.long,
             device=self.device,
         )
-        
+
         if self.cfg.use_sds:
             grad = self.compute_grad_sds(text_embeddings, latents, cond_latents, t)
             grad = torch.nan_to_num(grad)
@@ -281,27 +296,39 @@ class InstructPix2PixGuidance(BaseObject):
         else:
             edit_latents = self.edit_latents(text_embeddings, latents, cond_latents, t)
             edit_images = self.decode_latents(edit_latents)
-            edit_images = F.interpolate(edit_images, (H, W), mode='bilinear')
+            edit_images = F.interpolate(edit_images, (H, W), mode="bilinear")
 
-            return {
-                "edit_images": edit_images.permute(0, 2, 3, 1)
-            }
+            return {"edit_images": edit_images.permute(0, 2, 3, 1)}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from threestudio.utils.config import ExperimentConfig, load_config
     from threestudio.utils.typing import Optional
+
     cfg = load_config("configs/experimental/instructpix2pix.yaml")
     guidance = threestudio.find(cfg.system.guidance_type)(cfg.system.guidance)
-    prompt_processor = threestudio.find(cfg.system.prompt_processor_type)(cfg.system.prompt_processor)
-    rgb_image = cv2.imread('assets/face.jpg')[:, :, ::-1].copy() / 255
+    prompt_processor = threestudio.find(cfg.system.prompt_processor_type)(
+        cfg.system.prompt_processor
+    )
+    rgb_image = cv2.imread("assets/face.jpg")[:, :, ::-1].copy() / 255
     rgb_image = cv2.resize(rgb_image, (512, 512))
     rgb_image = torch.FloatTensor(rgb_image).unsqueeze(0).to(guidance.device)
     prompt_utils = prompt_processor()
-    guidance_out = guidance(
-        rgb_image, rgb_image, prompt_utils
+    guidance_out = guidance(rgb_image, rgb_image, prompt_utils)
+    edit_image = (
+        (
+            guidance_out["edit_images"][0]
+            .permute(1, 2, 0)
+            .detach()
+            .cpu()
+            .clip(0, 1)
+            .numpy()
+            * 255
+        )
+        .astype(np.uint8)[:, :, ::-1]
+        .copy()
     )
-    edit_image = (guidance_out['edit_images'][0].permute(1, 2, 0).detach().cpu().clip(0, 1).numpy()*255).astype(np.uint8)[:, :, ::-1].copy()
     import os
-    os.makedirs('.threestudio_cache', exist_ok=True)
-    cv2.imwrite('.threestudio_cache/edit_image.jpg', edit_image)
+
+    os.makedirs(".threestudio_cache", exist_ok=True)
+    cv2.imwrite(".threestudio_cache/edit_image.jpg", edit_image)

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -121,8 +121,8 @@ class StableDiffusionGuidance(BaseObject):
             )
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        # self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
+        # self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -121,8 +121,10 @@ class StableDiffusionGuidance(BaseObject):
             )
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        # self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        # self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        if isinstance(self.cfg.min_step_percent, int) and isinstance(
+            self.cfg.max_step_percent, int
+        ):
+            self.set_min_max_steps(self.cfg.min_step_percent, self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device

--- a/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_vsd_guidance.py
@@ -203,8 +203,10 @@ class StableDiffusionVSDGuidance(BaseModule):
         self.pipe_lora.scheduler = self.scheduler_lora
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        if isinstance(self.cfg.min_step_percent, int) and isinstance(
+            self.cfg.max_step_percent, int
+        ):
+            self.set_min_max_steps(self.cfg.min_step_percent, self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device

--- a/threestudio/models/guidance/zero123_guidance.py
+++ b/threestudio/models/guidance/zero123_guidance.py
@@ -126,8 +126,12 @@ class Zero123Guidance(BaseObject):
         )
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        # self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
+        # self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        if isinstance(self.cfg.min_step_percent, int) and isinstance(
+            self.cfg.max_step_percent, int
+        ):
+            self.set_min_max_steps(self.cfg.min_step_percent, self.cfg.max_step_percent)
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device

--- a/threestudio/systems/__init__.py
+++ b/threestudio/systems/__init__.py
@@ -1,11 +1,11 @@
 from . import (
+    control4d_multiview,
     dreamfusion,
     fantasia3d,
     imagedreamfusion,
+    instructnerf2nerf,
     latentnerf,
     magic3d,
-    instructnerf2nerf,
-    control4d_multiview,
     prolificdreamer,
     sjc,
     textmesh,

--- a/threestudio/systems/dreamfusion.py
+++ b/threestudio/systems/dreamfusion.py
@@ -37,6 +37,10 @@ class DreamFusion(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
         guidance_out = self.guidance(
             out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
         )

--- a/threestudio/systems/fantasia3d.py
+++ b/threestudio/systems/fantasia3d.py
@@ -53,6 +53,10 @@ class Fantasia3D(BaseLift3DSystem):
 
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
 
         if self.true_global_step < self.cfg.latent_steps:
             guidance_inp = torch.cat(

--- a/threestudio/systems/imagedreamfusion.py
+++ b/threestudio/systems/imagedreamfusion.py
@@ -123,11 +123,11 @@ class ImageConditionDreamFusion(BaseLift3DSystem):
                     valid_gt_depth = A @ X  # [B, 1]
                 set_loss("depth", F.mse_loss(valid_gt_depth, valid_pred_depth))
         elif guidance == "guidance":
+            prompt_utils = self.prompt_processor()
             self.guidance.set_min_max_steps(
                 self.C(self.guidance.cfg.min_step_percent),
                 self.C(self.guidance.cfg.max_step_percent),
             )
-            prompt_utils = self.prompt_processor()
             guidance_out = self.guidance(
                 out["comp_rgb"],
                 prompt_utils,

--- a/threestudio/systems/instructnerf2nerf.py
+++ b/threestudio/systems/instructnerf2nerf.py
@@ -7,8 +7,8 @@ import threestudio
 from threestudio.systems.base import BaseLift3DSystem
 from threestudio.utils.misc import cleanup, get_device
 from threestudio.utils.ops import binary_cross_entropy, dot
+from threestudio.utils.perceptual import PerceptualLoss
 from threestudio.utils.typing import *
-from threestudio.utils.perceptual import PerceptualLoss 
 
 
 @threestudio.register("instructnerf2nerf-system")
@@ -50,27 +50,39 @@ class Instructnerf2nerf(BaseLift3DSystem):
         if batch_index in self.edit_frames:
             gt_rgb = self.edit_frames[batch_index].to(batch["gt_rgb"].device)
             gt_rgb = torch.nn.functional.interpolate(
-                gt_rgb.permute(0, 3, 1, 2), (H, W), mode='bilinear', align_corners=False
+                gt_rgb.permute(0, 3, 1, 2), (H, W), mode="bilinear", align_corners=False
             ).permute(0, 2, 3, 1)
             batch["gt_rgb"] = gt_rgb
         else:
             gt_rgb = origin_gt_rgb
         out = self(batch)
-        if self.cfg.per_editing_step > 0 and self.global_step > self.cfg.start_editing_step:
+        if (
+            self.cfg.per_editing_step > 0
+            and self.global_step > self.cfg.start_editing_step
+        ):
             prompt_utils = self.prompt_processor()
-            if not batch_index in self.edit_frames or self.global_step % self.cfg.per_editing_step == 0:
+            self.guidance.set_min_max_steps(
+                self.C(self.guidance.cfg.min_step_percent),
+                self.C(self.guidance.cfg.max_step_percent),
+            )
+            if (
+                not batch_index in self.edit_frames
+                or self.global_step % self.cfg.per_editing_step == 0
+            ):
                 self.renderer.eval()
                 full_out = self(batch)
                 self.renderer.train()
-                result = self.guidance(full_out["comp_rgb"], origin_gt_rgb, prompt_utils)
+                result = self.guidance(
+                    full_out["comp_rgb"], origin_gt_rgb, prompt_utils
+                )
                 self.edit_frames[batch_index] = result["edit_images"].detach().cpu()
-        
+
         loss = 0.0
         guidance_out = {
             "loss_l1": torch.nn.functional.l1_loss(out["comp_rgb"], gt_rgb),
             "loss_p": self.perceptual_loss(
-                out["comp_rgb"].permute(0, 3, 1, 2).contiguous(), 
-                gt_rgb.permute(0, 3, 1, 2).contiguous()
+                out["comp_rgb"].permute(0, 3, 1, 2).contiguous(),
+                gt_rgb.permute(0, 3, 1, 2).contiguous(),
             ).sum(),
         }
 

--- a/threestudio/systems/latentnerf.py
+++ b/threestudio/systems/latentnerf.py
@@ -51,6 +51,10 @@ class LatentNeRF(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
         guidance_out = self.guidance(
             out["comp_rgb"],
             prompt_utils,

--- a/threestudio/systems/magic3d.py
+++ b/threestudio/systems/magic3d.py
@@ -39,6 +39,10 @@ class Magic3D(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
         guidance_out = self.guidance(
             out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
         )

--- a/threestudio/systems/prolificdreamer.py
+++ b/threestudio/systems/prolificdreamer.py
@@ -45,6 +45,11 @@ class ProlificDreamer(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
 
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
+
         if self.cfg.stage == "geometry":
             guidance_inp = out["comp_normal"]
             guidance_out = self.guidance(

--- a/threestudio/systems/sjc.py
+++ b/threestudio/systems/sjc.py
@@ -53,6 +53,10 @@ class ScoreJacobianChaining(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
         guidance_out = self.guidance(
             out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=True
         )

--- a/threestudio/systems/textmesh.py
+++ b/threestudio/systems/textmesh.py
@@ -40,6 +40,10 @@ class TextMesh(BaseLift3DSystem):
     def training_step(self, batch, batch_idx):
         out = self(batch)
         prompt_utils = self.prompt_processor()
+        self.guidance.set_min_max_steps(
+            self.C(self.guidance.cfg.min_step_percent),
+            self.C(self.guidance.cfg.max_step_percent),
+        )
         guidance_out = self.guidance(
             out["comp_rgb"], prompt_utils, **batch, rgb_as_latents=False
         )


### PR DESCRIPTION
Makes it possible to use `[start_iter, start_val, end_val, end_iter]` format for `min_step_percent` and `max_step_percent` for all cases (earlier it could be used only in Zero123).

Main changes are:
1. Adds `set_min_max_percent` to all guidances:
```py 
    @torch.cuda.amp.autocast(enabled=False)
    def set_min_max_steps(self, min_step_percent=0.02, max_step_percent=0.98):
        self.min_step = int(self.num_train_timesteps * min_step_percent)
        self.max_step = int(self.num_train_timesteps * max_step_percent)
```

2. Calls `set_min_max_percent` in all systems:
```py

      self.guidance.set_min_max_steps(
          self.C(self.guidance.cfg.min_step_percent),
          self.C(self.guidance.cfg.max_step_percent),
      )
```

3. Black formatter made its formatting changes to threestudio/models/guidance/controlnet_guidance.py and threestudio/models/guidance/instructpix2pix_guidance.py, threestudio/systems/control4d_multiview.py, threestudio/systems/instructnerf2nerf.py