### PR TITLE
Enable linearly changing min/max steps in guidance

### DIFF
--- a/configs/prolificdreamer-geometry.yaml
+++ b/configs/prolificdreamer-geometry.yaml
@@ -48,10 +48,8 @@ system:
     pretrained_model_name_or_path: "stabilityai/stable-diffusion-2-1-base"
     guidance_scale: 100.
     min_step_percent: 0.02
-    max_step_percent: 0.98
+    max_step_percent: [5000, 0.98, 0.5, 5001] # annealed to 0.5 after 5000 steps
     weighting_strategy: sds
-    max_step_percent_annealed: 0.5
-    anneal_start_step: 5000
 
   loggers:
     wandb:

--- a/configs/prolificdreamer-patch.yaml
+++ b/configs/prolificdreamer-patch.yaml
@@ -69,9 +69,7 @@ system:
     pretrained_model_name_or_path_lora: "stabilityai/stable-diffusion-2-1"
     guidance_scale: 7.5
     min_step_percent: 0.02
-    max_step_percent: 0.98
-    max_step_percent_annealed: 0.5
-    anneal_start_step: 5000
+    max_step_percent: [5000, 0.98, 0.5, 5001] # annealed to 0.5 after 5000 steps
 
   loggers:
     wandb:

--- a/configs/prolificdreamer-scene.yaml
+++ b/configs/prolificdreamer-scene.yaml
@@ -66,9 +66,7 @@ system:
     pretrained_model_name_or_path_lora: "stabilityai/stable-diffusion-2-1"
     guidance_scale: 7.5
     min_step_percent: 0.02
-    max_step_percent: 0.98
-    max_step_percent_annealed: 0.5
-    anneal_start_step: 10000
+    max_step_percent: [10000, 0.98, 0.5, 10001] # annealed to 0.5 after 10000 steps
     view_dependent_prompting: false
 
   loggers:

--- a/configs/prolificdreamer-texture.yaml
+++ b/configs/prolificdreamer-texture.yaml
@@ -62,9 +62,7 @@ system:
     pretrained_model_name_or_path_lora: "stabilityai/stable-diffusion-2-1"
     guidance_scale: 7.5
     min_step_percent: 0.02
-    max_step_percent: 0.98
-    max_step_percent_annealed: 0.5
-    anneal_start_step: 5000
+    max_step_percent: [5000, 0.98, 0.5, 5001] # annealed to 0.5 after 5000 steps
 
   loggers:
     wandb:

--- a/configs/prolificdreamer.yaml
+++ b/configs/prolificdreamer.yaml
@@ -69,9 +69,7 @@ system:
     pretrained_model_name_or_path_lora: "stabilityai/stable-diffusion-2-1"
     guidance_scale: 7.5
     min_step_percent: 0.02
-    max_step_percent: 0.98
-    max_step_percent_annealed: 0.5
-    anneal_start_step: 5000
+    max_step_percent: [5000, 0.98, 0.5, 5001] # annealed to 0.5 after 5000 steps
 
   loggers:
     wandb:

--- a/threestudio/models/guidance/deep_floyd_guidance.py
+++ b/threestudio/models/guidance/deep_floyd_guidance.py
@@ -91,8 +91,7 @@ class DeepFloydGuidance(BaseObject):
         self.scheduler = self.pipe.scheduler
 
         self.num_train_timesteps = self.scheduler.config.num_train_timesteps
-        self.min_step = int(self.num_train_timesteps * self.cfg.min_step_percent)
-        self.max_step = int(self.num_train_timesteps * self.cfg.max_step_percent)
+        self.set_min_max_steps()  # set to default value
 
         self.alphas: Float[Tensor, "..."] = self.scheduler.alphas_cumprod.to(
             self.device
@@ -249,6 +248,8 @@ class DeepFloydGuidance(BaseObject):
         guidance_out = {
             "loss_sds": loss_sds,
             "grad_norm": grad.norm(),
+            "min_step": self.min_step,
+            "max_step": self.max_step,
         }
 
         if guidance_eval:
@@ -405,6 +406,11 @@ class DeepFloydGuidance(BaseObject):
         # http://arxiv.org/abs/2303.15413
         if self.cfg.grad_clip is not None:
             self.grad_clip_val = C(self.cfg.grad_clip, epoch, global_step)
+
+        self.set_min_max_steps(
+            min_step_percent=C(self.cfg.min_step_percent, epoch, global_step),
+            max_step_percent=C(self.cfg.max_step_percent, epoch, global_step),
+        )
 
 
 """

--- a/threestudio/systems/zero123.py
+++ b/threestudio/systems/zero123.py
@@ -122,10 +122,6 @@ class Zero123(BaseLift3DSystem):
                     valid_gt_depth = A @ X  # [B, 1]
                 set_loss("depth", F.mse_loss(valid_gt_depth, valid_pred_depth))
         elif guidance == "zero123":
-            self.guidance.set_min_max_steps(
-                self.C(self.guidance.cfg.min_step_percent),
-                self.C(self.guidance.cfg.max_step_percent),
-            )
             # zero123
             guidance_out = self.guidance(
                 out["comp_rgb"],


### PR DESCRIPTION
This PR is related to #175 . I made the following changes:

- add `set_min_max_steps` to all guidance (as in #175)
- in the `update_step` hook of all guidance, use `C` to get the parsed value of `min_step` and `max_step` if they're specified by a tuple of four numbers
- add `min_step` and `max_step` to the return dict of the guidance, so that we could monitor the actual used value in tensorboard / wandb