### PR TITLE
fix resolution_milestones + batch_size in prolificdreamer configs

### DIFF
--- a/configs/prolificdreamer-scene.yaml
+++ b/configs/prolificdreamer-scene.yaml
@@ -5,7 +5,7 @@ seed: 0
 
 data_type: "random-camera-datamodule"
 data:
-  batch_size: 1
+  batch_size: [1, 1]
   # 0-4999: 64x64, >=5000: 512x512
   # this drastically reduces VRAM usage as empty space is pruned in early training
   width: [64, 512]

--- a/configs/prolificdreamer.yaml
+++ b/configs/prolificdreamer.yaml
@@ -5,7 +5,7 @@ seed: 0
 
 data_type: "random-camera-datamodule"
 data:
-  batch_size: 1
+  batch_size: [1, 1]
   # 0-4999: 64x64, >=5000: 512x512
   # this drastically reduces VRAM usage as empty space is pruned in early training
   width: [64, 512]


### PR DESCRIPTION
fix an `AssertionError` in prolificdreamer due to the batch size milestones check added in https://github.com/threestudio-project/threestudio/commit/1f3cb26c9044c710f6e838fc15324b7da64c539e.
```
assert len(self.heights) == len(self.widths) == len(self.batch_sizes)
```