### PR TITLE
detach vertices before adding to xatlas

### DIFF
--- a/threestudio/models/mesh.py
+++ b/threestudio/models/mesh.py
@@ -213,7 +213,7 @@ class Mesh:
 
         atlas = xatlas.Atlas()
         atlas.add_mesh(
-            self.v_pos.cpu().numpy(),
+            self.v_pos.detach().cpu().numpy(),
             self.t_pos_idx.cpu().numpy(),
         )
         co = xatlas.ChartOptions()


### PR DESCRIPTION
When doing the unwrap_uv in the Mesh class, the vertices are not detached from the computation graph, which will make xatlas raise an error.

This error can happen for example when using fantasia3d second stage without fixing the geometry.