### PR TITLE
max_items_to_save for `guidance_eval()`

### DIFF
--- a/configs/experimental/imagecondition_zero123nerf.yaml
+++ b/configs/experimental/imagecondition_zero123nerf.yaml
@@ -105,6 +105,7 @@ system:
     # min_step_percent: [0, 0.66, 0.33, 2000]  # (start_iter, start_val, end_val, end_iter)
     max_step_percent: 0.6
     # max_step_percent: [0, 0.98, 0.66, 2000]
+    max_items_to_save: 4
 
   # prompt_processor_type: "deep-floyd-prompt-processor"
   # prompt_processor:

--- a/configs/zero123.yaml
+++ b/configs/zero123.yaml
@@ -109,9 +109,10 @@ system:
     cond_camera_distance: ${data.default_camera_distance}
     guidance_scale: 3.0
     #min_step_percent: 0.02
-    min_step_percent: [0, 0.4, 0.02, 2000]  # (start_iter, start_val, end_val, end_iter)
+    min_step_percent: [0, 0.4, 0.02, 500]  # (start_iter, start_val, end_val, end_iter)
     #max_step_percent: 0.98
-    max_step_percent: [0, 0.85, 0.85, 2000]
+    max_step_percent: [0, 0.85, 0.85, 500]
+    max_items_to_save: 4
 
   freq:
     n_ref: 2
@@ -152,7 +153,7 @@ system:
         lr: 0.0
 
 trainer:
-  max_steps: 300
+  max_steps: 1000
   log_every_n_steps: 1
   num_sanity_val_steps: 0
   val_check_interval: 50

--- a/threestudio/models/guidance/stable_diffusion_guidance.py
+++ b/threestudio/models/guidance/stable_diffusion_guidance.py
@@ -44,6 +44,9 @@ class StableDiffusionGuidance(BaseObject):
 
         view_dependent_prompting: bool = True
 
+        """Maximum number of batch items to evaluate guidance for (for debugging) and to save on disk. -1 means save all items."""
+        max_items_to_save: int = 4
+
     cfg: Config
 
     def configure(self) -> None:
@@ -512,6 +515,9 @@ class StableDiffusionGuidance(BaseObject):
         self.scheduler.set_timesteps(50)
         self.scheduler.timesteps_gpu = self.scheduler.timesteps.to(self.device)
         bs = latents_noisy.shape[0]  # batch size
+        max_items = self.cfg.max_items_to_save
+        if max_items == -1:
+            max_items = bs
         large_enough_idxs = self.scheduler.timesteps_gpu.expand(
             [bs, -1]
         ) > t_orig.unsqueeze(
@@ -526,7 +532,7 @@ class StableDiffusionGuidance(BaseObject):
         # get prev latent
         latents_1step = []
         pred_1orig = []
-        for b in range(len(t)):
+        for b in range(max_items):
             step_output = self.scheduler.step(
                 noise_pred[b : b + 1], t[b], latents_noisy[b : b + 1], eta=1
             )
@@ -538,7 +544,7 @@ class StableDiffusionGuidance(BaseObject):
         imgs_1orig = self.decode_latents(pred_1orig).permute(0, 2, 3, 1)
 
         latents_final = []
-        for b, i in enumerate(idxs):
+        for b, i in enumerate(idxs[:max_items]):
             latents = latents_1step[b : b + 1]
             text_emb = (
                 text_embeddings[

--- a/threestudio/scripts/run_zero123_phase2.sh
+++ b/threestudio/scripts/run_zero123_phase2.sh
@@ -1,5 +1,20 @@
 # Reconstruct Anya using latest Zero123XL, in <2000 steps.
-python launch.py --config configs/zero123.yaml --train --gpu 0 system.loggers.wandb.enable=true system.loggers.wandb.project="voletiv-anya-new" system.loggers.wandb.name="claforte_params" data.image_path=./load/images/anya_front_rgba.png system.freq.ref_or_zero123="accumulate" system.freq.guidance_eval=13 system.guidance.pretrained_model_name_or_path="./load/zero123/XL_20230604.ckpt"
+debugpy-run launch.py -- --config configs/zero123.yaml --train system.loggers.wandb.enable=true system.loggers.wandb.project="claforte-anya-new" \
+ system.loggers.wandb.name="claforte_params" data.image_path=./load/images/anya_front_rgba.png \
+ system.freq.ref_or_zero123="accumulate" system.freq.guidance_eval=13 \
+ system.guidance.pretrained_model_name_or_path="./load/zero123/XL_20230604.ckpt"
+
+# claforte: at first sight, quality plateaued around step ~750
+#srun --account mod3d --partition=g40 --gpus=1 --job-name=3s_anya
+python launch.py --config configs/zero123.yaml --train system.loggers.wandb.enable=true system.loggers.wandb.project="claforte-anya-new" \
+ system.loggers.wandb.name="1000steps" data.image_path=./load/images/anya_front_rgba.png \
+ system.freq.ref_or_zero123="accumulate" system.freq.guidance_eval=13 \
+ system.guidance.pretrained_model_name_or_path="./load/zero123/XL_20230604.ckpt"
 
 # PHASE 2
-python launch.py --config configs/experimental/imagecondition_zero123nerf.yaml --train --gpu 0 system.prompt_processor.prompt="A DSLR 3D photo of a cute anime schoolgirl stands proudly with her arms in the air, pink hair ( unreal engine 5 trending on Artstation Ghibli 4k )" system.weights=outputs/zero123/128_anya_front_rgba.png@20230623-145711/ckpts/last.ckpt system.freq.guidance_eval=13 system.loggers.wandb.enable=true system.loggers.wandb.project="voletiv-anya-new" data.image_path=./load/images/anya_front_rgba.png system.loggers.wandb.name="anya" data.random_camera.progressive_until=500
+#srun --account mod3d --partition=g40 --gpus=1 --job-name=3s_anya \
+python launch.py --config configs/experimental/imagecondition_zero123nerf.yaml --train \
+ system.prompt_processor.prompt="A DSLR 3D photo of a cute anime schoolgirl stands proudly with her arms in the air, pink hair ( unreal engine 5 trending on Artstation Ghibli 4k )" \
+ system.weights="outputs/zero123/[64, 128]_anya_front_rgba.png_prog0@20230706-183840/ckpts/last.ckpt" system.freq.guidance_eval=13 \
+ system.loggers.wandb.enable=true system.loggers.wandb.project="claforte-anya-new-ph2" \
+ data.image_path=./load/images/anya_front_rgba.png system.loggers.wandb.name="baseline" data.random_camera.progressive_until=500

--- a/threestudio/systems/base.py
+++ b/threestudio/systems/base.py
@@ -309,6 +309,10 @@ class BaseLift3DSystem(BaseSystem):
 
     def guidance_evaluation_save(self, comp_rgb, guidance_eval_out):
         B, size = comp_rgb.shape[:2]
+        max_items = self.cfg.guidance.max_items_to_save
+        if max_items == -1:
+            max_items = B
+
         resize = lambda x: F.interpolate(
             x.permute(0, 3, 1, 2), (size, size), mode="bilinear", align_corners=False
         ).permute(0, 2, 3, 1)
@@ -322,7 +326,7 @@ class BaseLift3DSystem(BaseSystem):
             [
                 {
                     "type": "rgb",
-                    "img": merge12(comp_rgb),
+                    "img": merge12(comp_rgb[:max_items, ...]),
                     "kwargs": {"data_format": "HWC"},
                 },
             ]
@@ -330,7 +334,9 @@ class BaseLift3DSystem(BaseSystem):
                 [
                     {
                         "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_noisy"])),
+                        "img": merge12(
+                            resize(guidance_eval_out["imgs_noisy"][:max_items, ...])
+                        ),
                         "kwargs": {"data_format": "HWC"},
                     }
                 ]
@@ -339,7 +345,9 @@ class BaseLift3DSystem(BaseSystem):
                 [
                     {
                         "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_1step"])),
+                        "img": merge12(
+                            resize(guidance_eval_out["imgs_1step"][:max_items, ...])
+                        ),
                         "kwargs": {"data_format": "HWC"},
                     }
                 ]
@@ -348,7 +356,9 @@ class BaseLift3DSystem(BaseSystem):
                 [
                     {
                         "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_1orig"])),
+                        "img": merge12(
+                            resize(guidance_eval_out["imgs_1orig"][:max_items, ...])
+                        ),
                         "kwargs": {"data_format": "HWC"},
                     }
                 ]
@@ -357,12 +367,14 @@ class BaseLift3DSystem(BaseSystem):
                 [
                     {
                         "type": "rgb",
-                        "img": merge12(resize(guidance_eval_out["imgs_final"])),
+                        "img": merge12(
+                            resize(guidance_eval_out["imgs_final"][:max_items, ...])
+                        ),
                         "kwargs": {"data_format": "HWC"},
                     }
                 ]
             ),
             name="train_step",
             step=self.true_global_step,
-            texts=guidance_eval_out["texts"],
+            texts=guidance_eval_out["texts"][:max_items],
         )


### PR DESCRIPTION
- currently limited to zero123_guidance and stable_diffusion_guidance
- limits number of batch items to evaluate guidance for debugging purposes
  - defaults to 4
  - higher values (e.g. 12) resulted in very large images that were harder to analyze, took longer to evaluate
- also slightly improve hyperparams for anya phase 1
- TODO: avoid duplicating code...
 - part of guidance_eval logic should probably be moved in base class