### PR TITLE
Fix Multi-GPU Seed Problem

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -79,8 +79,8 @@ def main(args, extras) -> None:
         ProgressCallback,
     )
     from threestudio.utils.config import ExperimentConfig, load_config
-    from threestudio.utils.typing import Optional
     from threestudio.utils.misc import get_rank
+    from threestudio.utils.typing import Optional
 
     logger = logging.getLogger("pytorch_lightning")
     if args.verbose:
@@ -98,7 +98,8 @@ def main(args, extras) -> None:
     cfg: ExperimentConfig
     cfg = load_config(args.config, cli_args=extras, n_gpus=n_gpus)
 
-    seed_everything(cfg.seed, workers=True) # using same seed to init model weights
+    # set a different seed for each device
+    pl.seed_everything(cfg.seed + get_rank(), workers=True)
 
     dm = threestudio.find(cfg.data_type)(cfg.data)
     system: BaseSystem = threestudio.find(cfg.system_type)(
@@ -106,8 +107,6 @@ def main(args, extras) -> None:
     )
     system.set_save_dir(os.path.join(cfg.trial_dir, "save"))
 
-    seed_everything(cfg.seed + get_rank(), workers=True) # using different seed now for loading different data
-    
     if args.gradio:
         fh = logging.FileHandler(os.path.join(cfg.trial_dir, "logs"))
         fh.setLevel(logging.INFO)

--- a/launch.py
+++ b/launch.py
@@ -80,6 +80,7 @@ def main(args, extras) -> None:
     )
     from threestudio.utils.config import ExperimentConfig, load_config
     from threestudio.utils.typing import Optional
+    from threestudio.utils.misc import get_rank
 
     logger = logging.getLogger("pytorch_lightning")
     if args.verbose:
@@ -97,7 +98,7 @@ def main(args, extras) -> None:
     cfg: ExperimentConfig
     cfg = load_config(args.config, cli_args=extras, n_gpus=n_gpus)
 
-    pl.seed_everything(cfg.seed)
+    seed_everything(cfg.seed, workers=True) # using same seed to init model weights
 
     dm = threestudio.find(cfg.data_type)(cfg.data)
     system: BaseSystem = threestudio.find(cfg.system_type)(
@@ -105,6 +106,8 @@ def main(args, extras) -> None:
     )
     system.set_save_dir(os.path.join(cfg.trial_dir, "save"))
 
+    seed_everything(cfg.seed + get_rank(), workers=True) # using different seed now for loading different data
+    
     if args.gradio:
         fh = logging.FileHandler(os.path.join(cfg.trial_dir, "logs"))
         fh.setLevel(logging.INFO)

--- a/threestudio/models/geometry/implicit_sdf.py
+++ b/threestudio/models/geometry/implicit_sdf.py
@@ -10,7 +10,7 @@ import threestudio
 from threestudio.models.geometry.base import BaseImplicitGeometry, contract_to_unisphere
 from threestudio.models.mesh import Mesh
 from threestudio.models.networks import get_encoding, get_mlp
-from threestudio.utils.misc import get_rank
+from threestudio.utils.misc import broadcast, get_rank
 from threestudio.utils.typing import *
 
 
@@ -208,6 +208,10 @@ class ImplicitSDF(BaseImplicitGeometry):
             optim.zero_grad()
             loss.backward()
             optim.step()
+
+        # explicit broadcast to ensure param consistency across ranks
+        for param in self.parameters():
+            broadcast(param, src=0)
 
     def get_shifted_sdf(
         self, points: Float[Tensor, "*N Di"], sdf: Float[Tensor, "*N 1"]

--- a/threestudio/utils/misc.py
+++ b/threestudio/utils/misc.py
@@ -110,3 +110,11 @@ def barrier():
         return
     else:
         torch.distributed.barrier()
+
+
+def broadcast(tensor, src=0):
+    if not _distributed_available():
+        return tensor
+    else:
+        torch.distributed.broadcast(tensor, src=src)
+        return tensor


### PR DESCRIPTION
- Set a different seed for each device. We don't need to worry about the model initialization as Lightning will automatically sync the params across ranks.
- Manually sync the model params after optimization-based initialization as I found Lightning won't sync in this case.