### PR TITLE
Revert "Enable git-lfs and add 256_tets.npz"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-load/tets/256_tets.npz filter=lfs diff=lfs merge=lfs -text

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,10 +17,6 @@ Install [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive).
   - `sudo apt-key del 7fa2af80`
   - Run [command for CUDA 11.8 WSL-Ubuntu](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local)
 
-## Install Git LFS (Optional)
-
-To checkout resource files, such as precomputed large tetrahedral grids (256_tets.npz), please install and configure [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage).
-
 ## Git Clone
 
 ```bash

--- a/load/tets/256_tets.npz
+++ b/load/tets/256_tets.npz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:302db1a62668d04cadd03eacfc291f75efbb2987e894f0797bbb75730ac12b32
-size 60277787


### PR DESCRIPTION
Reverts threestudio-project/threestudio#224 due to Git LFS bandwidth limit 