### PR TITLE
Correct the normal direction of finite_difference

### DIFF
--- a/threestudio/models/geometry/implicit_volume.py
+++ b/threestudio/models/geometry/implicit_volume.py
@@ -170,7 +170,7 @@ class ImplicitVolume(BaseImplicitGeometry):
                     density_offset: Float[Tensor, "... 3 1"] = self.forward_density(
                         points_offset
                     )
-                    normal = (density_offset[..., 0::1, 0] - density) / eps
+                    normal = -(density_offset[..., 0::1, 0] - density) / eps
                 normal = F.normalize(normal, dim=-1)
             elif self.cfg.normal_type == "pred":
                 normal = self.normal_network(enc).view(*points.shape[:-1], 3)

--- a/threestudio/models/geometry/volume_grid.py
+++ b/threestudio/models/geometry/volume_grid.py
@@ -135,7 +135,7 @@ class VolumeGrid(BaseImplicitGeometry):
                     density_offset: Float[Tensor, "... 3 1"] = self.forward_density(
                         points_offset
                     )
-                    normal = (density_offset[..., 0::1, 0] - density) / eps
+                    normal = -(density_offset[..., 0::1, 0] - density) / eps
                 normal = F.normalize(normal, dim=-1)
             elif self.cfg.normal_type == "pred":
                 normal = self.get_trilinear_feature(points, self.normal_grid)


### PR DESCRIPTION
I find a mistake in my ```finite_difference``` implementation for NeRF. The direction of normal should be reversed.