### PR TITLE
avoid saving whole tensor with .clone()

### DIFF
--- a/threestudio/models/prompt_processors/deepfloyd_prompt_processor.py
+++ b/threestudio/models/prompt_processors/deepfloyd_prompt_processor.py
@@ -85,7 +85,7 @@ class DeepFloydPromptProcessor(PromptProcessor):
 
         for prompt, embedding in zip(prompts, text_embeddings):
             torch.save(
-                embedding,
+                embedding.clone(),
                 os.path.join(
                     cache_dir,
                     f"{hash_prompt(pretrained_model_name_or_path, prompt)}.pt",

--- a/threestudio/models/prompt_processors/stable_diffusion_prompt_processor.py
+++ b/threestudio/models/prompt_processors/stable_diffusion_prompt_processor.py
@@ -92,7 +92,7 @@ class StableDiffusionPromptProcessor(PromptProcessor):
 
         for prompt, embedding in zip(prompts, text_embeddings):
             torch.save(
-                embedding,
+                embedding.clone(),
                 os.path.join(
                     cache_dir,
                     f"{hash_prompt(pretrained_model_name_or_path, prompt)}.pt",


### PR DESCRIPTION
https://discuss.pytorch.org/t/saving-tensor-with-torch-save-uses-too-much-memory/46865/2

saving the text embedding as cache without .clone() will have the file size of whole tensor. 