### PR TITLE
Lock setuptools version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN groupadd -g ${GID} ${GROUP_NAME} \
     && useradd -ms /bin/sh -u ${UID} -g ${GID} ${USER_NAME}
 USER ${USER_NAME}
 
-RUN pip install --upgrade pip setuptools ninja
+RUN pip install --upgrade pip setuptools==69.5.1 ninja
 RUN pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 --index-url https://download.pytorch.org/whl/cu118
 # Install nerfacc and tiny-cuda-nn before installing requirements.txt
 # because these two installations are time consuming and error prone


### PR DESCRIPTION
RIght now docker build fails with an error:
```
 > [threestudio  6/10] RUN pip install git+https://github.com/KAIR-BAIR/nerfacc.git@v0.5.2:
0.340 Defaulting to user installation because normal site-packages is not writeable
0.362 Collecting git+https://github.com/KAIR-BAIR/nerfacc.git@v0.5.2
0.362   Cloning https://github.com/KAIR-BAIR/nerfacc.git (to revision v0.5.2) to /tmp/pip-req-build-l6bkrwqs
0.364   Running command git clone --filter=blob:none --quiet https://github.com/KAIR-BAIR/nerfacc.git /tmp/pip-req-build-l6bkrwqs
1.984   Running command git checkout -q d84cdf3afd7dcfc42150e0f0506db58a5ce62812
2.553   Resolved https://github.com/KAIR-BAIR/nerfacc.git to commit d84cdf3afd7dcfc42150e0f0506db58a5ce62812
2.554   Running command git submodule update --init --recursive -q
7.459   Preparing metadata (setup.py): started
8.497   Preparing metadata (setup.py): finished with status 'error'
8.501   error: subprocess-exited-with-error
8.501
8.501   × python setup.py egg_info did not run successfully.
8.501   │ exit code: 1
8.501   ╰─> [10 lines of output]
8.501       Traceback (most recent call last):
8.501         File "<string>", line 2, in <module>
8.501         File "<pip-setuptools-caller>", line 34, in <module>
8.501         File "/tmp/pip-req-build-l6bkrwqs/setup.py", line 123, in <module>
8.501           ext_modules=get_extensions() if not BUILD_NO_CUDA else [],
8.501         File "/tmp/pip-req-build-l6bkrwqs/setup.py", line 29, in get_extensions
8.501           from torch.utils.cpp_extension import CUDAExtension
8.501         File "/home/dreamer/.local/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 25, in <module>
8.501           from pkg_resources import packaging  # type: ignore[attr-defined]
8.501       ImportError: cannot import name 'packaging' from 'pkg_resources' (/home/dreamer/.local/lib/python3.10/site-packages/pkg_resources/__init__.py)
8.501       [end of output]
8.501
8.501   note: This error originates from a subprocess, and is likely not a problem with pip.
8.502 error: metadata-generation-failed
8.502
8.502 × Encountered error while generating package metadata.
8.502 ╰─> See above for output.
8.502
8.502 note: This is an issue with the package mentioned above, not pip.
8.502 hint: See above for details.
```
This change fixes the problem.