### PR TITLE
Update requirements.txt.(Restricted hugging_hub version to set lower than 0.26.0.)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ xformers
 bitsandbytes==0.38.1
 sentencepiece
 safetensors
-huggingface_hub
+huggingface_hub<0.26.0
 
 # for zero123
 einops


### PR DESCRIPTION
Currently, the diffusers package in requirements.txt is set to install a version lower than version 0.20.0. In diffusers < 0.20.0, the cached_download function of huggingface_hub is used, which was completely removed after version 0.26.0, so the version of huggingfac_hub needs to be set lower than version 0.26.0.